### PR TITLE
json parsing fixes

### DIFF
--- a/src/binpickingtask.cpp
+++ b/src/binpickingtask.cpp
@@ -1629,11 +1629,7 @@ std::string GetValueForSmallestSlaveRequestId(const std::string& heartbeat,
 
     
 std::string mujinclient::utils::GetScenePkFromHeatbeat(const std::string& heartbeat) {
-#if defined(_WIN32) || defined(_WIN64)
-    static const std::string prefix("mujin:"); // "slash is replaced with empty string in windows
-#else
     static const std::string prefix("mujin:/");
-#endif
     return GetValueForSmallestSlaveRequestId(heartbeat, "currentsceneuri").substr(prefix.length());
 }
 

--- a/src/binpickingtask.cpp
+++ b/src/binpickingtask.cpp
@@ -112,7 +112,11 @@ void BinPickingTaskResource::Initialize(const std::string& defaultTaskParameters
     if( defaultTaskParameters.size() > 0 ) {
         boost::property_tree::ptree pt;
         std::stringstream ss(defaultTaskParameters);
+#if defined(_WIN32) || defined(_WIN64)
+        ParsePropertyTreeWin(ss.str(), pt);
+#else
         boost::property_tree::read_json(ss, pt);
+#endif
         FOREACH(itchild, pt) {
             std::string value = itchild->second.data();
             // hack?!
@@ -143,7 +147,11 @@ void BinPickingTaskResource::Initialize(const std::string& defaultTaskParameters
     if( defaultTaskParameters.size() > 0 ) {
         boost::property_tree::ptree pt;
         std::stringstream ss(defaultTaskParameters);
+#if defined(_WIN32) || defined(_WIN64)
+        ParsePropertyTreeWin(ss.str(), pt);
+#else
         boost::property_tree::read_json(ss, pt);
+#endif
         FOREACH(itchild, pt) {
             const std::string value = itchild->second.data();
             // hack?!
@@ -1602,8 +1610,11 @@ std::string GetValueForSmallestSlaveRequestId(const std::string& heartbeat,
 {
     boost::property_tree::ptree pt;
     std::stringstream ss(heartbeat);
+#if defined(_WIN32) || defined(_WIN64)
+    ParsePropertyTreeWin(ss.str(), pt);
+#else
     boost::property_tree::read_json(ss, pt);
-
+#endif
     try {
         const std::string slavereqid = FindSmallestSlaveRequestId(pt);
 
@@ -1618,19 +1629,25 @@ std::string GetValueForSmallestSlaveRequestId(const std::string& heartbeat,
 
     
 std::string mujinclient::utils::GetScenePkFromHeatbeat(const std::string& heartbeat) {
-    static const std::string prefix("mujin:\/");
+#if defined(_WIN32) || defined(_WIN64)
+    static const std::string prefix("mujin:"); // "slash is replaced with empty string in windows
+#else
+    static const std::string prefix("mujin:/");
+#endif
     return GetValueForSmallestSlaveRequestId(heartbeat, "currentsceneuri").substr(prefix.length());
 }
 
 std::string utils::GetSlaveRequestIdFromHeatbeat(const std::string& heartbeat) {
     boost::property_tree::ptree pt;
     std::stringstream ss(heartbeat);
+#if defined(_WIN32) || defined(_WIN64)
+    ParsePropertyTreeWin(ss.str(), pt);
+#else
     boost::property_tree::read_json(ss, pt);
-
+#endif
     try {
         static const std::string prefix("slaverequestid-");
         return FindSmallestSlaveRequestId(pt).substr(prefix.length());
-;
     }
     catch (const MujinException& ex) {
         throw MujinException(boost::str(boost::format("%s from heartbeat:\n%s")%ex.what()%heartbeat));

--- a/src/binpickingtaskzmq.cpp
+++ b/src/binpickingtaskzmq.cpp
@@ -172,6 +172,7 @@ boost::property_tree::ptree BinPickingTaskZmqResource::ExecuteCommand(const std:
             std::vector< std::pair<std::string, std::string> > serachpairs(2);
             serachpairs[0].first = "\n"; serachpairs[0].second = "";
             serachpairs[1].first = "\\"; serachpairs[1].second = "";
+            serachpairs[1].first = "\/"; serachpairs[1].second = "";
             SearchAndReplace(newbuffer, result_ss_float_timestamp.str(), serachpairs);
             std::stringstream newss(newbuffer);
             boost::property_tree::read_json(newss, pt);

--- a/src/binpickingtaskzmq.cpp
+++ b/src/binpickingtaskzmq.cpp
@@ -45,7 +45,7 @@ void ConvertTimestampToFloat(const std::string& in,
         {
             throw mujinclient::MujinException(boost::str(boost::format("error while converting timestamp value format for %s")%in), mujinclient::MEC_Failed);
         }
-        const std::size_t timestampend = timestampbegin + std::min(comma, closingCurly);
+        const std::size_t timestampend = timestampbegin + (comma < closingCurly ? comma : closingCurly);
         if (timestampend == std::string::npos) {
             throw mujinclient::MujinException(boost::str(boost::format("error while converting timestamp value format for %s")%in), mujinclient::MEC_Failed);
         }

--- a/src/binpickingtaskzmq.cpp
+++ b/src/binpickingtaskzmq.cpp
@@ -166,9 +166,18 @@ boost::property_tree::ptree BinPickingTaskZmqResource::ExecuteCommand(const std:
             // temporary fix until we move on to rapid json
             std::stringstream result_ss_float_timestamp;
             ConvertTimestampToFloat(result_ss.str(), result_ss_float_timestamp);
-            std::cout << result_ss.str() << std::endl
-                      << result_ss_float_timestamp.str() << std::endl;
+#ifdef _WIN32
+            // sometimes buffer can container \n or \\, which windows boost property_tree does not like
+            std::string newbuffer;
+            std::vector< std::pair<std::string, std::string> > serachpairs(2);
+            serachpairs[0].first = "\n"; serachpairs[0].second = "";
+            serachpairs[1].first = "\\"; serachpairs[1].second = "";
+            SearchAndReplace(newbuffer, result_ss_float_timestamp.str(), serachpairs);
+            std::stringstream newss(newbuffer);
+            boost::property_tree::read_json(newss, pt);
+#else
             boost::property_tree::read_json(result_ss_float_timestamp, pt);
+#endif
             boost::property_tree::ptree::const_assoc_iterator iterror = pt.find("error");
             if( iterror != pt.not_found() ) {
                 boost::optional<std::string> erroroptional = iterror->second.get_optional<std::string>("errorcode");

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -135,9 +135,8 @@ void ConvertTimestampToFloat(const std::string& in,
 
 
 void ParsePropertyTreeWin(const std::string& originalStr,
-		                   boost::property_tree::ptree& pt)
+                          boost::property_tree::ptree& pt)
 {
-
     // sometimes buffer can containe \n, \\ and so on, which windows boost property_tree does not like
     std::string newbuffer1, newbuffer2;
     {

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -92,7 +92,72 @@ const std::map<int, std::string>& GetCodePageMap()
     return s_mapCodePageToCharset;
 }
 
+
 #endif
 
 } // namespace encoding
+
+void ConvertTimestampToFloat(const std::string& in,
+                             std::stringstream& outss)
+{
+    const std::size_t len = in.size();
+    std::size_t processed = 0;
+    while (processed != std::string::npos && processed < len) {
+        const std::size_t deltabegin = in.substr(processed, len).find("\"timestamp\":");
+        if (deltabegin == std::string::npos) {
+            outss << in.substr(processed, len);
+            return;
+        }
+        const std::size_t timestampbegin = processed + deltabegin;
+        const std::size_t comma = in.substr(timestampbegin, len).find(",");
+        const std::size_t closingCurly = in.substr(timestampbegin, len).find("}");
+        if (comma == std::string::npos && closingCurly == std::string::npos)
+        {
+            throw mujinclient::MujinException(boost::str(boost::format("error while converting timestamp value format for %s")%in), mujinclient::MEC_Failed);
+        }
+        const std::size_t timestampend = timestampbegin + (comma < closingCurly ? comma : closingCurly);
+        if (timestampend == std::string::npos) {
+            throw mujinclient::MujinException(boost::str(boost::format("error while converting timestamp value format for %s")%in), mujinclient::MEC_Failed);
+        }
+        const std::size_t period = in.substr(timestampbegin, len).find(".");
+
+        if (period == std::string::npos || timestampbegin + period > timestampend) {
+            // no comma, assume this is in integet format. so add period to make it a float format.
+            outss << in.substr(processed, timestampend - processed) << ".";
+        }
+        else {
+            // already floating format. keep it that way
+            outss << in.substr(processed, timestampend - processed);
+        }
+        processed = timestampend;
+    }
+}
+
+
+void ParsePropertyTreeWin(const std::string& originalStr,
+		                   boost::property_tree::ptree& pt)
+{
+
+    // sometimes buffer can containe \n, \\ and so on, which windows boost property_tree does not like
+    std::string newbuffer1, newbuffer2;
+    {
+        // need to first deal with this case alone. since dealing with "\\\"" and "\\" simultaneously does not give us good result.
+        // for example, input string "\\\"", it can be matched by both "\\\"" and "\\" and result is not predictable.
+        std::vector< std::pair<std::string, std::string> > serachpairs_first(1);
+        serachpairs_first[0].first = "\\\""; serachpairs_first[0].second = "";
+        mujinclient::SearchAndReplace(newbuffer1, originalStr, serachpairs_first);
+    }
+    {
+        std::vector< std::pair<std::string, std::string> > serachpairs_second(3);
+        serachpairs_second[0].first = "\/"; serachpairs_second[0].second = "";
+        serachpairs_second[1].first = "\\"; serachpairs_second[1].second = "";
+        serachpairs_second[2].first = "\\n"; serachpairs_second[2].second = " ";
+        mujinclient::SearchAndReplace(newbuffer2, newbuffer1, serachpairs_second);
+    }
+
+    std::stringstream newss;
+    ConvertTimestampToFloat(newbuffer2, newss);
+    boost::property_tree::read_json(newss, pt);
+}
+
 } // namespace mujinclient

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -143,16 +143,16 @@ void ParsePropertyTreeWin(const std::string& originalStr,
     {
         // need to first deal with this case alone. since dealing with "\\\"" and "\\" simultaneously does not give us good result.
         // for example, input string "\\\"", it can be matched by both "\\\"" and "\\" and result is not predictable.
-        std::vector< std::pair<std::string, std::string> > serachpairs_first(1);
-        serachpairs_first[0].first = "\\\""; serachpairs_first[0].second = "";
-        mujinclient::SearchAndReplace(newbuffer1, originalStr, serachpairs_first);
+        std::vector< std::pair<std::string, std::string> > serachpairs(1);
+        serachpairs[0].first = "\\\""; serachpairs[0].second = "";
+        mujinclient::SearchAndReplace(newbuffer1, originalStr, serachpairs);
     }
     {
-        std::vector< std::pair<std::string, std::string> > serachpairs_second(3);
-        serachpairs_second[0].first = "\/"; serachpairs_second[0].second = "";
-        serachpairs_second[1].first = "\\"; serachpairs_second[1].second = "";
-        serachpairs_second[2].first = "\\n"; serachpairs_second[2].second = " ";
-        mujinclient::SearchAndReplace(newbuffer2, newbuffer1, serachpairs_second);
+        std::vector< std::pair<std::string, std::string> > serachpairs(3);
+        serachpairs[0].first = "\\/"; serachpairs[0].second = "";
+        serachpairs[1].first = "\\"; serachpairs[1].second = "";
+        serachpairs[2].first = "\\n"; serachpairs[2].second = " ";
+        mujinclient::SearchAndReplace(newbuffer2, newbuffer1, serachpairs);
     }
 
     std::stringstream newss;

--- a/src/common.h
+++ b/src/common.h
@@ -366,6 +366,12 @@ const char s_filesep = '/';
 const wchar_t s_wfilesep = L'/';
 #endif
 
+/// \brief parses string into boost property_tree
+/// do string manipulation so that boost in Windows can parse input string without throwing exception
+/// \param originalStr input string to be parsed into property_tree
+/// \param pt output property_tree
+void ParsePropertyTreeWin(const std::string& originalStr,
+                          boost::property_tree::ptree& pt);
 } // end namespace mujinclient
 
 #endif

--- a/src/controllerclientimpl.cpp
+++ b/src/controllerclientimpl.cpp
@@ -683,7 +683,7 @@ int ControllerClientImpl::_CallGet(const std::string& desturi, boost::property_t
     CHECKCURLCODE(res, "curl_easy_getinfo");
     if( _buffer.rdbuf()->in_avail() > 0 ) {
 #if defined(_WIN32) || defined(_WIN64)
-		ParsePropertyTreeWin(_buffer.str(), pt);
+        ParsePropertyTreeWin(_buffer.str(), pt);
 #else
         boost::property_tree::read_json(_buffer, pt);
 #endif
@@ -724,9 +724,9 @@ int ControllerClientImpl::_CallGet(const std::string& desturi, std::string& outp
         if( outputdata.size() > 0 ) {
             boost::property_tree::ptree pt;
 #if defined(_WIN32) || defined(_WIN64)
-	    	ParsePropertyTreeWin(_buffer.str(), pt);
+            ParsePropertyTreeWin(_buffer.str(), pt);
 #else
-			boost::property_tree::read_json(_buffer, pt);
+            boost::property_tree::read_json(_buffer, pt);
 #endif
             std::string error_message = pt.get<std::string>("error_message", std::string());
             std::string traceback = pt.get<std::string>("traceback", std::string());
@@ -769,7 +769,7 @@ int ControllerClientImpl::_CallGet(const std::string& desturi, std::vector<unsig
             try {
                 boost::property_tree::ptree pt;
 #if defined(_WIN32) || defined(_WIN64)
-        		ParsePropertyTreeWin(ss.str(), pt);
+                ParsePropertyTreeWin(ss.str(), pt);
 #else
                 boost::property_tree::read_json(ss, pt);
 #endif
@@ -810,7 +810,7 @@ int ControllerClientImpl::CallPost(const std::string& relativeuri, const std::st
     CHECKCURLCODE(res, "curl_easy_getinfo failed");
     if( _buffer.rdbuf()->in_avail() > 0 ) {
 #if defined(_WIN32) || defined(_WIN64)
-		ParsePropertyTreeWin(_buffer.str(), pt);
+        ParsePropertyTreeWin(_buffer.str(), pt);
 #else
         boost::property_tree::read_json(_buffer, pt);
 #endif
@@ -856,7 +856,7 @@ int ControllerClientImpl::CallPut(const std::string& relativeuri, const std::str
     CHECKCURLCODE(res, "curl_easy_getinfo failed");
     if( _buffer.rdbuf()->in_avail() > 0 ) {
 #if defined(_WIN32) || defined(_WIN64)
-		ParsePropertyTreeWin(_buffer.str(), pt);
+        ParsePropertyTreeWin(_buffer.str(), pt);
 #else
         boost::property_tree::read_json(_buffer, pt);
 #endif

--- a/src/controllerclientimpl.cpp
+++ b/src/controllerclientimpl.cpp
@@ -25,6 +25,7 @@ MUJIN_LOGGER("mujin.controllerclientcpp");
 
 #define CURL_OPTION_SAVER(curl, curlopt, curvalue, curltype) boost::shared_ptr<void> __curloptionsaver ## curlopt((void*)0, boost::bind(boost::function<CURLcode(CURL*, CURLoption, curltype)>(curl_easy_setopt), curl, curlopt, curvalue));
 
+
 namespace mujinclient {
 
 class CurlTimeoutSetter
@@ -681,15 +682,8 @@ int ControllerClientImpl::_CallGet(const std::string& desturi, boost::property_t
     res=curl_easy_getinfo (_curl, CURLINFO_RESPONSE_CODE, &http_code);
     CHECKCURLCODE(res, "curl_easy_getinfo");
     if( _buffer.rdbuf()->in_avail() > 0 ) {
-#ifdef _WIN32
-        // sometimes buffer can container \n or \\, which windows boost property_tree does not like
-        std::string newbuffer;
-        std::vector< std::pair<std::string, std::string> > serachpairs(2);
-        serachpairs[0].first = "\n"; serachpairs[0].second = "";
-        serachpairs[1].first = "\\"; serachpairs[1].second = "";
-        SearchAndReplace(newbuffer, _buffer.str(), serachpairs);
-        std::stringstream newss(newbuffer);
-        boost::property_tree::read_json(newss, pt);
+#if defined(_WIN32) || defined(_WIN64)
+		ParsePropertyTreeWin(_buffer.str(), pt);
 #else
         boost::property_tree::read_json(_buffer, pt);
 #endif
@@ -729,7 +723,11 @@ int ControllerClientImpl::_CallGet(const std::string& desturi, std::string& outp
     if( expectedhttpcode != 0 && http_code != expectedhttpcode ) {
         if( outputdata.size() > 0 ) {
             boost::property_tree::ptree pt;
-            boost::property_tree::read_json(_buffer, pt);
+#if defined(_WIN32) || defined(_WIN64)
+	    	ParsePropertyTreeWin(_buffer.str(), pt);
+#else
+			boost::property_tree::read_json(_buffer, pt);
+#endif
             std::string error_message = pt.get<std::string>("error_message", std::string());
             std::string traceback = pt.get<std::string>("traceback", std::string());
             throw MUJIN_EXCEPTION_FORMAT("HTTP GET to '%s' returned HTTP status %s: %s", desturi%http_code%error_message, MEC_HTTPServer);
@@ -770,7 +768,11 @@ int ControllerClientImpl::_CallGet(const std::string& desturi, std::vector<unsig
             std::string error_message, traceback;
             try {
                 boost::property_tree::ptree pt;
+#if defined(_WIN32) || defined(_WIN64)
+        		ParsePropertyTreeWin(ss.str(), pt);
+#else
                 boost::property_tree::read_json(ss, pt);
+#endif
                 error_message = pt.get<std::string>("error_message", std::string());
                 traceback = pt.get<std::string>("traceback", std::string());
             }
@@ -807,7 +809,11 @@ int ControllerClientImpl::CallPost(const std::string& relativeuri, const std::st
     res = curl_easy_getinfo (_curl, CURLINFO_RESPONSE_CODE, &http_code);
     CHECKCURLCODE(res, "curl_easy_getinfo failed");
     if( _buffer.rdbuf()->in_avail() > 0 ) {
+#if defined(_WIN32) || defined(_WIN64)
+		ParsePropertyTreeWin(_buffer.str(), pt);
+#else
         boost::property_tree::read_json(_buffer, pt);
+#endif
     }
     if( expectedhttpcode != 0 && http_code != expectedhttpcode ) {
         std::string error_message = pt.get<std::string>("error_message", std::string());
@@ -849,7 +855,11 @@ int ControllerClientImpl::CallPut(const std::string& relativeuri, const std::str
     res = curl_easy_getinfo (_curl, CURLINFO_RESPONSE_CODE, &http_code);
     CHECKCURLCODE(res, "curl_easy_getinfo failed");
     if( _buffer.rdbuf()->in_avail() > 0 ) {
+#if defined(_WIN32) || defined(_WIN64)
+		ParsePropertyTreeWin(_buffer.str(), pt);
+#else
         boost::property_tree::read_json(_buffer, pt);
+#endif
     }
     if( expectedhttpcode != 0 && http_code != expectedhttpcode ) {
         std::string error_message = pt.get<std::string>("error_message", std::string());


### PR DESCRIPTION
implemented
- added common interface to manipulate json string so that it can be parsed by boost read_json
- cleaned up code so that every call to read_json from Windows uses above interface

tested
- sample programs (jog, movetool) work from Linux and Windows on actual robot and simulation
- third party UI calling these API can move robot and simulation
- exception thrown by server is propagated properly, including message obtained by ex.what()