### PR TITLE
Generalized WebResource::Get

### DIFF
--- a/include/mujincontrollerclient/mujincontrollerclient.h
+++ b/include/mujincontrollerclient/mujincontrollerclient.h
@@ -599,7 +599,12 @@ public:
     }
 
     /// \brief gets an attribute of this web resource
-    virtual std::string Get(const std::string& field, double timeout = 5.0);
+    template<class T>
+    T Get(const std::string& field, double timeout = 5.0) {
+        rapidjson::Document pt(rapidjson::kObjectType);
+        GetWrap(pt, field, timeout);
+        return mujinjson::GetJsonValueByKey<T>(pt, field.c_str());
+    }
 
     /// \brief sets an attribute of this web resource
     virtual void Set(const std::string& field, const std::string& newvalue, double timeout = 5.0);
@@ -611,6 +616,8 @@ public:
     virtual void Copy(const std::string& newname, int options, double timeout = 5.0);
 
 private:
+    virtual void GetWrap(rapidjson::Document& pt, const std::string& field, double timeout = 5.0);
+
     ControllerClientPtr __controller;
     std::string __resourcename, __pk;
 };

--- a/src/handeyecalibrationtask.cpp
+++ b/src/handeyecalibrationtask.cpp
@@ -61,7 +61,7 @@ HandEyeCalibrationTaskResource::HandEyeCalibrationTaskResource(const std::string
 std::string HandEyeCalibrationTaskResource::_GetOrCreateTaskAndGetPk(SceneResourcePtr scene, const std::string& taskname)
 {
     TaskResourcePtr task = scene->GetOrCreateTaskFromName_UTF8(taskname,"handeyecalibration");
-    std::string pk = task->Get("pk");
+    std::string pk = task->Get<std::string>("pk");
     return pk;
 }
 

--- a/src/mujincontrollerclient.cpp
+++ b/src/mujincontrollerclient.cpp
@@ -101,13 +101,10 @@ WebResource::WebResource(ControllerClientPtr controller, const std::string& reso
     BOOST_ASSERT(__pk.size()>0);
 }
 
-std::string WebResource::Get(const std::string& field, double timeout)
+void WebResource::GetWrap(rapidjson::Document& pt, const std::string& field, double timeout)
 {
     GETCONTROLLERIMPL();
-    rapidjson::Document pt(rapidjson::kObjectType);
-    controller->CallGet(str(boost::format("%s/%s/?format=json&fields=%s")%GetResourceName()%GetPrimaryKey()%field), pt, timeout);
-    std::string fieldvalue = GetJsonValueByKey<std::string>(pt, field.c_str());
-    return fieldvalue;
+    controller->CallGet(str(boost::format("%s/%s/?format=json&fields=%s")%GetResourceName()%GetPrimaryKey()%field), pt, 200, timeout);
 }
 
 void WebResource::Set(const std::string& field, const std::string& newvalue, double timeout)


### PR DESCRIPTION
Since WebResource::Get is general method, it should be templated, I think.

The point is GETCONTROLLERIMPL() is not exported to include (it is in src/common.h), so I made a private (could be protected?) wrapper function named GetWrap which calls API.
