### PR TITLE
fix form upload

### DIFF
--- a/samples/mujinupgrade.cpp
+++ b/samples/mujinupgrade.cpp
@@ -13,7 +13,9 @@
 #include <sstream>
 
 #if defined(_WIN32) || defined(_WIN64)
+#include <windows.h>
 #undef GetUserName // clashes with ControllerClient::GetUserName
+#define sleep(n) Sleep((n)*1000)
 #endif // defined(_WIN32) || defined(_WIN64)
 
 using namespace mujinclient;

--- a/src/controllerclientimpl.cpp
+++ b/src/controllerclientimpl.cpp
@@ -1272,7 +1272,7 @@ void ControllerClientImpl::Upgrade(std::istream& inputStream, bool autorestart, 
         throw MUJIN_EXCEPTION_FORMAT0("failed to rewind inputStream", MEC_InvalidArguments);
     }
 
-    if(!contentLength) {
+    if(contentLength) {
         _UploadFileToControllerViaForm(inputStream, "", _baseuri+"upgrade/"+query, timeout);
     } else {
         rapidjson::Document pt(rapidjson::kObjectType);
@@ -1722,7 +1722,7 @@ void ControllerClientImpl::_UploadFileToControllerViaForm(std::istream& inputStr
                  CURLFORM_COPYNAME, "files[]",
                  CURLFORM_FILENAME, filename.empty() ? "unused" : filename.c_str(),
                  CURLFORM_STREAM, &inputStream,
-                 CURLFORM_CONTENTSLENGTH, contentLength,
+                 CURLFORM_CONTENTSLENGTH, (std::streamoff)contentLength,
                  CURLFORM_END);
     if(!filename.empty()) {
         curl_formadd(&formpost, &lastptr,


### PR DESCRIPTION
tested

- save/restore backup automated gtest (as modifying UploadViaForm could break backup feature)
- upgrading with uploading
- upgrading without uploading

very sorry for mistesting.

also contains mujinupgrade Windows compilation fix.