### PR TITLE
Fix form upload windows

### DIFF
--- a/src/controllerclientimpl.cpp
+++ b/src/controllerclientimpl.cpp
@@ -1722,7 +1722,7 @@ void ControllerClientImpl::_UploadFileToControllerViaForm(std::istream& inputStr
                  CURLFORM_COPYNAME, "files[]",
                  CURLFORM_FILENAME, filename.empty() ? "unused" : filename.c_str(),
                  CURLFORM_STREAM, &inputStream,
-#if LIBCURL_VERSION_MAJOR<7 || (LIBCURL_VERSION_MAJOR==7&&LIBCURLVERSION_MINOR<46)
+#if !CURL_AT_LEAST_VERSION(7,46,0)
                  // According to curl/lib/formdata.c, CURLFORM_CONTENTSLENGTH argument type is long.
                  // Also, as va_list is used in curl_formadd, the bit length needs to match exactly.
                  // streamoff can be directly converted to streamoff, but it does not correspond on 32bit machines.

--- a/src/controllerclientimpl.cpp
+++ b/src/controllerclientimpl.cpp
@@ -1722,14 +1722,14 @@ void ControllerClientImpl::_UploadFileToControllerViaForm(std::istream& inputStr
                  CURLFORM_COPYNAME, "files[]",
                  CURLFORM_FILENAME, filename.empty() ? "unused" : filename.c_str(),
                  CURLFORM_STREAM, &inputStream,
-#if LIBCURL_VERSION_MAJOR<=7 && (LIBCURL_VERSION_MAJOR==7&&LIBCURLVERSION_MINOR<46)
+#if LIBCURL_VERSION_MAJOR<7 || (LIBCURL_VERSION_MAJOR==7&&LIBCURLVERSION_MINOR<46)
                  // According to curl/lib/formdata.c, CURLFORM_CONTENTSLENGTH argument type is long.
                  // Also, as va_list is used in curl_formadd, the bit length needs to match exactly.
                  // streamoff can be directly converted to streamoff, but it does not correspond on 32bit machines.
                  CURLFORM_CONTENTSLENGTH, (long)contentLength,
 #else
                  // Actually we should use CURLFORM_CONTENTLEN, whose argument type is curl_off_t, which is 64bit.
-                 // However, it was added in curl 1.46 and cannot be used in official Windows build.
+                 // However, it was added in curl 7.46 and cannot be used in official Windows build.
                  CURLFORM_CONTENTLEN, (curl_off_t)contentLength,
 #endif
                  CURLFORM_END);

--- a/src/controllerclientimpl.cpp
+++ b/src/controllerclientimpl.cpp
@@ -1722,7 +1722,16 @@ void ControllerClientImpl::_UploadFileToControllerViaForm(std::istream& inputStr
                  CURLFORM_COPYNAME, "files[]",
                  CURLFORM_FILENAME, filename.empty() ? "unused" : filename.c_str(),
                  CURLFORM_STREAM, &inputStream,
-                 CURLFORM_CONTENTSLENGTH, (std::streamoff)contentLength,
+#if LIBCURL_VERSION_MAJOR<=7 && (LIBCURL_VERSION_MAJOR==7&&LIBCURLVERSION_MINOR<46)
+                 // According to curl/lib/formdata.c, CURLFORM_CONTENTSLENGTH argument type is long.
+                 // Also, as va_list is used in curl_formadd, the bit length needs to match exactly.
+                 // streamoff can be directly converted to streamoff, but it does not correspond on 32bit machines.
+                 CURLFORM_CONTENTSLENGTH, (long)contentLength,
+#else
+                 // Actually we should use CURLFORM_CONTENTLEN, whose argument type is curl_off_t, which is 64bit.
+                 // However, it was added in curl 1.46 and cannot be used in official Windows build.
+                 CURLFORM_CONTENTLEN, (curl_off_t)contentLength,
+#endif
                  CURLFORM_END);
     if(!filename.empty()) {
         curl_formadd(&formpost, &lastptr,


### PR DESCRIPTION
curl_formadd uses vararg and wrong bitlength can cause crash.

I had a report from customer.