### PR TITLE
Clean up MUJIN_ASSERT, everyone else is using BOOST_ASSERT.

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -199,17 +199,6 @@ inline static unsigned long long GetNanoPerformanceTime()
 /// adds the function name and line number to an exception
 #define MUJIN_EXCEPTION_FORMAT(s, args,errorcode) mujinclient::MujinException(boost::str(boost::format("[%s:%d] " s)%(__PRETTY_FUNCTION__)%(__LINE__)%args),errorcode)
 
-#define MUJIN_ASSERT_FORMAT(testexpr, s, args, errorcode) { if( !(testexpr) ) { throw mujinclient::MujinException(boost::str(boost::format("[%s:%d] (%s) failed " s)%(__PRETTY_FUNCTION__)%(__LINE__)%(# testexpr)%args),errorcode); } }
-
-#define MUJIN_ASSERT_FORMAT0(testexpr, s, errorcode) { if( !(testexpr) ) { throw mujinclient::MujinException(boost::str(boost::format("[%s:%d] (%s) failed " s)%(__PRETTY_FUNCTION__)%(__LINE__)%(# testexpr)),errorcode); } }
-
-// note that expr1 and expr2 will be evaluated twice if not equal
-#define MUJIN_ASSERT_OP_FORMAT(expr1,op,expr2,s, args, errorcode) { if( !((expr1) op (expr2)) ) { throw mujinclient::MujinException(boost::str(boost::format("[%s:%d] %s %s %s, (eval %s %s %s) " s)%(__PRETTY_FUNCTION__)%(__LINE__)%(# expr1)%(# op)%(# expr2)%(expr1)%(# op)%(expr2)%args),errorcode); } }
-
-#define MUJIN_ASSERT_OP_FORMAT0(expr1,op,expr2,s, errorcode) { if( !((expr1) op (expr2)) ) { throw mujinclient::MujinException(boost::str(boost::format("[%s:%d] %s %s %s, (eval %s %s %s) " s)%(__PRETTY_FUNCTION__)%(__LINE__)%(# expr1)%(# op)%(# expr2)%(expr1)%(# op)%(expr2)),errorcode); } }
-
-#define MUJIN_ASSERT_OP(expr1,op,expr2) { if( !((expr1) op (expr2)) ) { throw mujinclient::MujinException(boost::str(boost::format("[%s:%d] %s %s %s, (eval %s %s %s) ")%(__PRETTY_FUNCTION__)%(__LINE__)%(# expr1)%(# op)%(# expr2)%(expr1)%(# op)%(expr2)),MEC_Assert); } }
-
 BOOST_STATIC_ASSERT(sizeof(unsigned short) == 2); // need this for utf-16 reading
 
 namespace mujinclient {

--- a/src/controllerclientimpl.cpp
+++ b/src/controllerclientimpl.cpp
@@ -818,7 +818,9 @@ const std::string& ControllerClientImpl::GetDefaultTaskType()
 std::string ControllerClientImpl::GetScenePrimaryKeyFromURI_UTF8(const std::string& uri)
 {
     size_t index = uri.find(":/");
-    MUJIN_ASSERT_OP_FORMAT(index,!=,std::string::npos, "bad URI: %s", uri, MEC_InvalidArguments);
+    if (index == std::string::npos) {
+        throw MUJIN_EXCEPTION_FORMAT("bad URI: %s", uri, MEC_InvalidArguments);
+    }
     return EscapeString(uri.substr(index+2));
 }
 
@@ -1412,7 +1414,9 @@ void ControllerClientImpl::_UploadDirectoryToController_UTF8(const std::string& 
         }
     }
     else {
-        MUJIN_ASSERT_OP_FORMAT(copydir_utf8.at(copydir_utf8.size()-1),!=,s_filesep,"copydir '%s' cannot end in slash '%s'", copydir_utf8%s_filesep, MEC_InvalidArguments);
+        if (copydir_utf8.at(copydir_utf8.size()-1) == s_filesep) {
+            throw MUJIN_EXCEPTION_FORMAT("copydir '%s' cannot end in slash '%s'", copydir_utf8%s_filesep, MEC_InvalidArguments);
+        }
         uri = rawuri;
     }
 
@@ -1526,7 +1530,9 @@ void ControllerClientImpl::_UploadDirectoryToController_UTF16(const std::wstring
         }
     }
     else {
-        MUJIN_ASSERT_OP_FORMAT(copydir_utf16.at(copydir_utf16.size()-1),!=,s_wfilesep,"copydir '%s' cannot end in slash '%s'", encoding::ConvertUTF16ToFileSystemEncoding(copydir_utf16)%s_filesep, MEC_InvalidArguments);
+        if (copydir_utf16.at(copydir_utf16.size()-1) == s_wfilesep) {
+            throw MUJIN_EXCEPTION_FORMAT("copydir '%s' cannot end in slash '%s'", encoding::ConvertUTF16ToFileSystemEncoding(copydir_utf16)%s_filesep, MEC_InvalidArguments);
+        }
         uri = rawuri;
     }
 

--- a/src/mujincontrollerclient.cpp
+++ b/src/mujincontrollerclient.cpp
@@ -167,7 +167,9 @@ void ObjectResource::GeometryResource::GetMesh(std::string& primitive, std::vect
 void ObjectResource::GeometryResource::SetGeometryFromRawSTL(const std::vector<unsigned char>& rawstldata, const std::string& unit, double timeout)
 {
     GETCONTROLLERIMPL();
-    MUJIN_ASSERT_OP_FORMAT(this->geomtype,!=,"mesh", "geomtype is not mesh: %s", this->geomtype, MEC_InvalidArguments);
+    if (this->geomtype != "mesh") {
+        throw MUJIN_EXCEPTION_FORMAT("geomtype is not mesh: %s", this->geomtype, MEC_InvalidArguments);
+    }
     controller->SetObjectGeometryMesh(this->objectpk, this->pk, rawstldata, unit, timeout);
 }
 
@@ -655,7 +657,9 @@ TaskResourcePtr SceneResource::GetOrCreateTaskFromName_UTF8(const std::string& t
 void SceneResource::SetInstObjectsState(const std::vector<SceneResource::InstObjectPtr>& instobjects, const std::vector<InstanceObjectState>& states)
 {
     GETCONTROLLERIMPL();
-    MUJIN_ASSERT_OP_FORMAT(instobjects.size(), ==, states.size(), "the size of instobjects (%d) and the one of states (%d) must be the same",instobjects.size()%states.size(),MEC_InvalidArguments);
+    if (instobjects.size() != states.size()) {
+        throw MUJIN_EXCEPTION_FORMAT("the size of instobjects (%d) and the one of states (%d) must be the same",instobjects.size()%states.size(),MEC_InvalidArguments);
+    }
     boost::format transformtemplate("{\"pk\":\"%s\",\"quaternion\":[%.15f, %.15f, %.15f, %.15f], \"translate\":[%.15f, %.15f, %.15f] %s}");
     std::string datastring, sdofvalues;
     for(size_t i = 0; i < instobjects.size(); ++i) {


### PR DESCRIPTION
- 5 places in the code uses `MUJIN_ASSERT_*`
- 42 places in the code uses `BOOST_ASSERT`
- `RAPIDJSON_ASSERT` uses `BOOST_ASSERT`

Clean up `MUJIN_ASSERT_*` to avoid leaking the assert exception across libraries.