### PR TITLE
Set cookie domain

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -190,6 +190,15 @@ inline static unsigned long long GetNanoPerformanceTime()
 #define CHECKCURLCODE(code, msg) if (code != CURLE_OK) { \
         throw MujinException(boost::str(boost::format("[%s:%d] curl function %s with error '%s': %s")%(__PRETTY_FUNCTION__)%(__LINE__)%(msg)%curl_easy_strerror(code)%_errormessage), MEC_HTTPClient); \
 }
+#if CURL_AT_LEAST_VERSION(7,80,0)
+#define CHECKCURLUCODE(code, msg) if (code != CURLUE_OK) { \
+        throw MujinException(boost::str(boost::format("[%s:%d] curl function %s with error '%s': %s")%(__PRETTY_FUNCTION__)%(__LINE__)%(msg)%curl_url_strerror(code)%_errormessage), MEC_HTTPClient); \
+}
+#else
+#define CHECKCURLUCODE(code, msg) if (code != CURLUE_OK) { \
+        throw MujinException(boost::str(boost::format("[%s:%d] curl function %s with error %d: %s")%(__PRETTY_FUNCTION__)%(__LINE__)%(msg)%(code)%_errormessage), MEC_HTTPClient); \
+}
+#endif
 
 #define MUJIN_EXCEPTION_FORMAT0(s, errorcode) mujinclient::MujinException(boost::str(boost::format("[%s:%d] " s)%(__PRETTY_FUNCTION__)%(__LINE__)),errorcode)
 

--- a/src/controllerclientimpl.cpp
+++ b/src/controllerclientimpl.cpp
@@ -190,6 +190,8 @@ ControllerClientImpl::ControllerClientImpl(const std::string& usernamepassword, 
     // csrftoken can be any non-empty string
     _csrfmiddlewaretoken = "csrftoken";
     std::string cookie = "Set-Cookie: csrftoken=" + _csrfmiddlewaretoken;
+#if CURL_AT_LEAST_VERSION(7,60,0)
+    // with https://github.com/curl/curl/commit/b8d5036ec9b702d6392c97a6fc2e141d6c7cce1f, setting domain param to cookie is required.
     if(_baseuri.find('/') == _baseuri.size()-1) {
         // _baseuri should be hostname with trailing slash
         cookie += "; domain=";
@@ -209,6 +211,7 @@ ControllerClientImpl::ControllerClientImpl(const std::string& usernamepassword, 
         }
         curl_url_cleanup(url);
     }
+#endif
     CURL_OPTION_SETTER(_curl, CURLOPT_COOKIELIST, cookie.c_str());
 
     _charset = "utf-8";

--- a/src/controllerclientimpl.cpp
+++ b/src/controllerclientimpl.cpp
@@ -197,25 +197,20 @@ ControllerClientImpl::ControllerClientImpl(const std::string& usernamepassword, 
         cookie += "; domain=";
         cookie += _baseuri.substr(0,_baseuri.size()-1);
     } else {
-        CURLUcode rc;
         CURLU *url = curl_url();
         BOOST_SCOPE_EXIT_ALL(&url) {
             curl_url_cleanup(url);
         };
-        rc = curl_url_set(url, CURLUPART_URL, _baseuri.c_str(), 0);
-        if(!rc) {
-            char *host = NULL;
-            BOOST_SCOPE_EXIT_ALL(&host) {
-                if(host) {
-                    curl_free(host);
-                }
-            };
-            rc = curl_url_get(url, CURLUPART_HOST, &host, 0);
-            if(!rc) {
-                cookie += "; domain=";
-                cookie += host;
+        CHECKCURLUCODE(curl_url_set(url, CURLUPART_URL, _baseuri.c_str(), 0), "cannot parse url");
+        char *host = NULL;
+        BOOST_SCOPE_EXIT_ALL(&host) {
+            if(host) {
+                curl_free(host);
             }
-        }
+        };
+        CHECKCURLUCODE(curl_url_get(url, CURLUPART_HOST, &host, 0), "cannot determine hostname from url");
+        cookie += "; domain=";
+        cookie += host;
     }
 #endif
     CURL_OPTION_SETTER(_curl, CURLOPT_COOKIELIST, cookie.c_str());

--- a/src/controllerclientimpl.cpp
+++ b/src/controllerclientimpl.cpp
@@ -15,7 +15,7 @@
 #include "controllerclientimpl.h"
 
 #include <boost/algorithm/string.hpp>
-
+#include <boost/scope_exit.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 
 #define SKIP_PEER_VERIFICATION // temporary
@@ -199,17 +199,23 @@ ControllerClientImpl::ControllerClientImpl(const std::string& usernamepassword, 
     } else {
         CURLUcode rc;
         CURLU *url = curl_url();
+        BOOST_SCOPE_EXIT_ALL(&url) {
+            curl_url_cleanup(url);
+        };
         rc = curl_url_set(url, CURLUPART_URL, _baseuri.c_str(), 0);
         if(!rc) {
-            char *host;
+            char *host = NULL;
+            BOOST_SCOPE_EXIT_ALL(&host) {
+                if(host) {
+                    curl_free(host);
+                }
+            };
             rc = curl_url_get(url, CURLUPART_HOST, &host, 0);
             if(!rc) {
                 cookie += "; domain=";
                 cookie += host;
-                curl_free(host);
             }
         }
-        curl_url_cleanup(url);
     }
 #endif
     CURL_OPTION_SETTER(_curl, CURLOPT_COOKIELIST, cookie.c_str());

--- a/src/controllerclientimpl.cpp
+++ b/src/controllerclientimpl.cpp
@@ -190,6 +190,25 @@ ControllerClientImpl::ControllerClientImpl(const std::string& usernamepassword, 
     // csrftoken can be any non-empty string
     _csrfmiddlewaretoken = "csrftoken";
     std::string cookie = "Set-Cookie: csrftoken=" + _csrfmiddlewaretoken;
+    if(_baseuri.find('/') == _baseuri.size()-1) {
+        // _baseuri should be hostname with trailing slash
+        cookie += "; domain=";
+        cookie += _baseuri.substr(0,_baseuri.size()-1);
+    } else {
+        CURLUcode rc;
+        CURLU *url = curl_url();
+        rc = curl_url_set(url, CURLUPART_URL, _baseuri.c_str(), 0);
+        if(!rc) {
+            char *host;
+            rc = curl_url_get(url, CURLUPART_HOST, &host, 0);
+            if(!rc) {
+                cookie += "; domain=";
+                cookie += host;
+                curl_free(host);
+            }
+        }
+        curl_url_cleanup(url);
+    }
     CURL_OPTION_SETTER(_curl, CURLOPT_COOKIELIST, cookie.c_str());
 
     _charset = "utf-8";


### PR DESCRIPTION
Starting in 7.43.0 any-domain cookies will not be exported

cf https://curl.se/libcurl/c/cookie_interface.html

@ziyan (although I tested locally) could you confirm master does not work on debian bullseye?