### PR TITLE
_PrepareDestinationURI_UTF16 should not lock mutex, safe to assume it is already locked

### DIFF
--- a/src/controllerclientimpl.cpp
+++ b/src/controllerclientimpl.cpp
@@ -1131,7 +1131,6 @@ std::string ControllerClientImpl::_PrepareDestinationURI_UTF8(const std::string&
 
 std::string ControllerClientImpl::_PrepareDestinationURI_UTF16(const std::wstring& rawuri_utf16, bool bEnsurePath, bool bEnsureSlash, bool bIsDirectory)
 {
-    boost::mutex::scoped_lock lock(_mutex);
     std::string baseuploaduri;
     std::string desturi_utf8;
     utf8::utf16to8(rawuri_utf16.begin(), rawuri_utf16.end(), std::back_inserter(desturi_utf8));


### PR DESCRIPTION
test script

```
//usr/bin/env true; tmpfile=$(mktemp); g++ -O2 -std=c++11 -xc++ -o $tmpfile $0 -Dutf16=$UTF16 -I $MUJIN_INSTALL_DIR/include -L $MUJIN_INSTALL_DIR/lib -lmujincontrollerclient0.44 && $tmpfile; rm $tmpfile; exit

#include <iostream>
#include <mujincontrollerclient/mujincontrollerclient.h>

int main(){
    auto client = mujinclient::CreateControllerClient("mujin:mujin", "foobar");
    std::vector<unsigned char> vdata;
#if(utf16)
    client->DownloadFileFromController_UTF16(L"mujin:/foobar.xyz", vdata);
#else
    client->DownloadFileFromController_UTF8("mujin:/foobar.xyz", vdata);
#endif
}
```

result

```
$ UTF16=0 ./clientcpptest.cpp
log4cxx: No appender could be found for logger (mujin.controllerclientcpp).
log4cxx: Please initialize the log4cxx system properly.
terminate called after throwing an instance of 'mujinclient::MujinException'
  what():  mujin (HTTPClient): [int mujinclient::ControllerClientImpl::_CallGet(const string&, std::vector<unsigned char>&, int, double):681] curl function curl_easy_perform with error 'Couldn't resolve host name': Could not resolve host: foobar
cpptest/clientcpptest.cpp: line 1: 4191991 Aborted                 $tmpfile
$ UTF16=1 ./clientcpptest.cpp
log4cxx: No appender could be found for logger (mujin.controllerclientcpp).
log4cxx: Please initialize the log4cxx system properly.
(freezes forever)
```