### PR TITLE
Silence ZMQ related warnings

### DIFF
--- a/include/mujincontrollerclient/mujinjson.h
+++ b/include/mujincontrollerclient/mujinjson.h
@@ -164,7 +164,7 @@ inline void ParseJson(rapidjson::Document& d, const std::string& str) {
 inline void ParseJson(rapidjson::Document& d, std::istream& is) {
     rapidjson::IStreamWrapper isw(is);
     // see note in: void ParseJson(rapidjson::Document& d, const std::string& str)
-    rapidjson::Document(tempDoc);
+    rapidjson::Document tempDoc;
     tempDoc.ParseStream<rapidjson::kParseFullPrecisionFlag>(isw); // parse float in full precision mode
     if (tempDoc.HasParseError()) {
         throw MujinJSONException(boost::str(boost::format("Json stream is invalid (offset %u) %s")%((unsigned)d.GetErrorOffset())%GetParseError_En(d.GetParseError())), MJE_Failed);

--- a/src/binpickingtask.cpp
+++ b/src/binpickingtask.cpp
@@ -1771,9 +1771,7 @@ void BinPickingTaskResource::_HeartbeatMonitorThread(const double reinitializeti
         socket->set(zmq::sockopt::tcp_keepalive_idle, 2); // the interval between the last data packet sent (simple ACKs are not considered data) and the first keepalive probe; after the connection is marked to need keepalive, this counter is not used any further
         socket->set(zmq::sockopt::tcp_keepalive_intvl, 2); // the interval between subsequential keepalive probes, regardless of what the connection has exchanged in the meantime
         socket->set(zmq::sockopt::tcp_keepalive_cnt, 2); // the number of unacknowledged probes to send before considering the connection dead and notifying the application layer
-        std::stringstream ss; ss << std::setprecision(std::numeric_limits<double>::digits10+1);
-        ss << _heartbeatPort;
-        socket->connect("tcp://"+ _mujinControllerIp+":"+ss.str());
+        socket->connect("tcp://" +  _mujinControllerIp + ":" + std::to_string(_heartbeatPort));
         socket->set(zmq::sockopt::subscribe, "");
 
         zmq::pollitem_t pollitem;
@@ -1882,8 +1880,7 @@ std::string GetValueForSmallestSlaveRequestId(const std::string& heartbeat, cons
 {
 
     rapidjson::Document pt(rapidjson::kObjectType);
-    std::stringstream ss(heartbeat);
-    ParseJson(pt, ss.str());
+    ParseJson(pt, heartbeat);
     try {
         const std::string slavereqid = FindSmallestSlaveRequestId(pt);
         std::string result;
@@ -1905,8 +1902,7 @@ std::string mujinclient::utils::GetScenePkFromHeatbeat(const std::string& heartb
 
 std::string utils::GetSlaveRequestIdFromHeatbeat(const std::string& heartbeat) {
     rapidjson::Document pt;
-    std::stringstream ss(heartbeat);
-    ParseJson(pt, ss.str());
+    ParseJson(pt, heartbeat);
     try {
         static const std::string prefix("slaverequestid-");
         return FindSmallestSlaveRequestId(pt).substr(prefix.length());

--- a/src/binpickingtaskzmq.cpp
+++ b/src/binpickingtaskzmq.cpp
@@ -271,9 +271,7 @@ void BinPickingTaskZmqResource::_HeartbeatMonitorThread(const double reinitializ
         socket->set(zmq::sockopt::tcp_keepalive_idle, 2); // the interval between the last data packet sent (simple ACKs are not considered data) and the first keepalive probe; after the connection is marked to need keepalive, this counter is not used any further
         socket->set(zmq::sockopt::tcp_keepalive_intvl, 2); // the interval between subsequential keepalive probes, regardless of what the connection has exchanged in the meantime
         socket->set(zmq::sockopt::tcp_keepalive_cnt, 2); // the number of unacknowledged probes to send before considering the connection dead and notifying the application layer
-        std::stringstream ss; ss << std::setprecision(std::numeric_limits<double>::digits10+1);
-        ss << _heartbeatPort;
-        socket->connect("tcp://"+ _mujinControllerIp+":"+ss.str());
+        socket->connect("tcp://" +  _mujinControllerIp + ":" + std::to_string(_heartbeatPort));
         socket->set(zmq::sockopt::subscribe, "");
 
         zmq::pollitem_t pollitem;
@@ -288,8 +286,7 @@ void BinPickingTaskZmqResource::_HeartbeatMonitorThread(const double reinitializ
                 socket->recv(reply);
                 rapidjson::Document pt(rapidjson::kObjectType);
                 try{
-                    std::stringstream replystring_ss(reply.to_string());
-                    ParseJson(pt, replystring_ss.str());
+                    ParseJson(pt, reply.to_string());
                     heartbeat.Parse(pt);
                     {
                         boost::mutex::scoped_lock lock(_mutexTaskState);

--- a/src/mujinzmq.cpp
+++ b/src/mujinzmq.cpp
@@ -157,9 +157,7 @@ void ZmqSubscriber::_InitializeSocket(boost::shared_ptr<zmq::context_t> context)
     _socket->set(zmq::sockopt::tcp_keepalive_cnt, 2); // the number of unacknowledged probes to send before considering the connection dead and notifying the application layer
     _socket->set(zmq::sockopt::sndhwm, 2);
     _socket->set(zmq::sockopt::linger, 100); // ms
-    std::ostringstream port_stream;
-    port_stream << "tcp://" << _host << ':' << _port;
-    _socket->connect(port_stream.str());
+    _socket->connect("tcp://" + _host + ':' + std::to_string(_port));
     _socket->set(zmq::sockopt::subscribe, "");
 }
 
@@ -209,9 +207,7 @@ void ZmqPublisher::_InitializeSocket(boost::shared_ptr<zmq::context_t> context)
     _socket->set(zmq::sockopt::tcp_keepalive_cnt, 2); // the number of unacknowledged probes to send before considering the connection dead and notifying the application layer
     _socket->set(zmq::sockopt::sndhwm, 2);
     _socket->set(zmq::sockopt::linger, 100); // ms
-    std::ostringstream port_stream;
-    port_stream << "tcp://*:" << _port;
-    _socket->bind(port_stream.str());
+    _socket->bind("tcp://*:" + std::to_string(_port));
 }
 
 void ZmqPublisher::_DestroySocket()
@@ -277,10 +273,9 @@ std::string ZmqClient::Call(const std::string& msg, const double timeout, const 
                 _InitializeSocket(_context);
                 recreatedonce = true;
             } else{
-                std::stringstream ss;
-                ss << "Failed to send request after re-creating socket.";
-                MUJIN_LOG_ERROR(ss.str());
-                throw MujinException(ss.str(), MEC_Failed);
+                std::string ss = "Failed to send request after re-creating socket.";
+                MUJIN_LOG_ERROR(ss);
+                throw MujinException(ss, MEC_Failed);
             }
         }
         if( !!_preemptfn ) {
@@ -289,15 +284,14 @@ std::string ZmqClient::Call(const std::string& msg, const double timeout, const 
 
     }
     if (GetMilliTime() - starttime > timeout*1000.0) {
-        std::stringstream ss;
-        ss << "Timed out trying to send request.";
-        MUJIN_LOG_ERROR(ss.str());
+        std::string ss = "Timed out trying to send request.";
+        MUJIN_LOG_ERROR(ss);
         if (msg.length() > 1000) {
             MUJIN_LOG_INFO(msg.substr(0,1000) << "...");
         } else {
             MUJIN_LOG_INFO(msg);
         }
-        throw MujinException(ss.str(), MEC_Timeout);
+        throw MujinException(ss, MEC_Timeout);
     }
     //recv
     recreatedonce = false;
@@ -377,15 +371,14 @@ std::string ZmqClient::Call(const std::string& msg, const double timeout, const 
         }
     }
     if (GetMilliTime() - starttime > timeout*1000.0) {
-        std::stringstream ss;
-        ss << "timed out trying to receive request";
-        MUJIN_LOG_ERROR(ss.str());
+        std::string ss = "timed out trying to receive request";
+        MUJIN_LOG_ERROR(ss);
         if (msg.length() > 1000) {
             MUJIN_LOG_INFO(msg.substr(0,1000) << "...");
         } else {
             MUJIN_LOG_INFO(msg);
         }
-        throw MujinException(ss.str(), MEC_Failed);
+        throw MujinException(ss, MEC_Failed);
     }
 
     return "";
@@ -405,12 +398,9 @@ void ZmqClient::_InitializeSocket(boost::shared_ptr<zmq::context_t> context)
     _socket->set(zmq::sockopt::tcp_keepalive_idle, 2); // the interval between the last data packet sent (simple ACKs are not considered data) and the first keepalive probe; after the connection is marked to need keepalive, this counter is not used any further
     _socket->set(zmq::sockopt::tcp_keepalive_intvl, 2); // the interval between subsequential keepalive probes, regardless of what the connection has exchanged in the meantime
     _socket->set(zmq::sockopt::tcp_keepalive_cnt, 2); // the number of unacknowledged probes to send before considering the connection dead and notifying the application layer
-    std::ostringstream port_stream;
-    port_stream << "tcp://" << _host << ':' << _port;
-    std::stringstream ss;
-    ss << "connecting to socket at " << _host << ":" << _port;
-    MUJIN_LOG_INFO(ss.str());
-    _socket->connect(port_stream.str());
+    std::string endpoint = "tcp://" + _host + ':' + std::to_string(_port);
+    MUJIN_LOG_INFO("connecting to socket at " + endpoint);
+    _socket->connect(endpoint);
 }
 
 void ZmqClient::_DestroySocket()
@@ -481,12 +471,9 @@ void ZmqServer::_InitializeSocket(boost::shared_ptr<zmq::context_t> context)
     _pollitem.socket = _socket->operator void*();
     _pollitem.events = ZMQ_POLLIN;
 
-    std::ostringstream endpoint;
-    endpoint << "tcp://*:" << _port;
-    _socket->bind(endpoint.str());
-    std::stringstream ss;
-    ss << "binded to " << endpoint.str();
-    MUJIN_LOG_INFO(ss.str());
+    std::string endpoint = "tcp://*:" + std::to_string(_port);
+    _socket->bind(endpoint);
+    MUJIN_LOG_INFO("binded to " + endpoint);
 }
 
 void ZmqServer::_DestroySocket()

--- a/src/mujinzmq.cpp
+++ b/src/mujinzmq.cpp
@@ -151,16 +151,16 @@ void ZmqSubscriber::_InitializeSocket(boost::shared_ptr<zmq::context_t> context)
         _sharedcontext = false;
     }
     _socket.reset(new zmq::socket_t ((*_context.get()), ZMQ_SUB));
-    _socket->setsockopt(ZMQ_TCP_KEEPALIVE, 1); // turn on tcp keepalive, do these configuration before connect
-    _socket->setsockopt(ZMQ_TCP_KEEPALIVE_IDLE, 2); // the interval between the last data packet sent (simple ACKs are not considered data) and the first keepalive probe; after the connection is marked to need keepalive, this counter is not used any further
-    _socket->setsockopt(ZMQ_TCP_KEEPALIVE_INTVL, 2); // the interval between subsequential keepalive probes, regardless of what the connection has exchanged in the meantime
-    _socket->setsockopt(ZMQ_TCP_KEEPALIVE_CNT, 2); // the number of unacknowledged probes to send before considering the connection dead and notifying the application layer
-    _socket->setsockopt(ZMQ_SNDHWM, 2); 
-    _socket->setsockopt(ZMQ_LINGER, 100); // ms
+    _socket->set(zmq::sockopt::tcp_keepalive, 1); // turn on tcp keepalive, do these configuration before connect
+    _socket->set(zmq::sockopt::tcp_keepalive_idle, 2); // the interval between the last data packet sent (simple ACKs are not considered data) and the first keepalive probe; after the connection is marked to need keepalive, this counter is not used any further
+    _socket->set(zmq::sockopt::tcp_keepalive_intvl, 2); // the interval between subsequential keepalive probes, regardless of what the connection has exchanged in the meantime
+    _socket->set(zmq::sockopt::tcp_keepalive_cnt, 2); // the number of unacknowledged probes to send before considering the connection dead and notifying the application layer
+    _socket->set(zmq::sockopt::sndhwm, 2);
+    _socket->set(zmq::sockopt::linger, 100); // ms
     std::ostringstream port_stream;
-    port_stream << _port;
-    _socket->connect (("tcp://" + _host + ":" + port_stream.str()).c_str());
-    _socket->setsockopt(ZMQ_SUBSCRIBE, "", 0);
+    port_stream << "tcp://" << _host << ':' << _port;
+    _socket->connect(port_stream.str());
+    _socket->set(zmq::sockopt::subscribe, "");
 }
 
 void ZmqSubscriber::_DestroySocket()
@@ -189,7 +189,7 @@ bool ZmqPublisher::Publish(const std::string& messagestr)
 {
     zmq::message_t message(messagestr.size());
     memcpy(message.data(), messagestr.data(), messagestr.size());
-    return _socket->send(message);
+    return (bool)_socket->send(message, zmq::send_flags::none);
 }
 
 void ZmqPublisher::_InitializeSocket(boost::shared_ptr<zmq::context_t> context)
@@ -203,15 +203,15 @@ void ZmqPublisher::_InitializeSocket(boost::shared_ptr<zmq::context_t> context)
         _sharedcontext = false;
     }
     _socket.reset(new zmq::socket_t ((*(zmq::context_t*)_context.get()), ZMQ_PUB));
-    _socket->setsockopt(ZMQ_TCP_KEEPALIVE, 1); // turn on tcp keepalive, do these configuration before connect
-    _socket->setsockopt(ZMQ_TCP_KEEPALIVE_IDLE, 2); // the interval between the last data packet sent (simple ACKs are not considered data) and the first keepalive probe; after the connection is marked to need keepalive, this counter is not used any further
-    _socket->setsockopt(ZMQ_TCP_KEEPALIVE_INTVL, 2); // the interval between subsequential keepalive probes, regardless of what the connection has exchanged in the meantime
-    _socket->setsockopt(ZMQ_TCP_KEEPALIVE_CNT, 2); // the number of unacknowledged probes to send before considering the connection dead and notifying the application layer
-    _socket->setsockopt(ZMQ_SNDHWM, 2);
-    _socket->setsockopt(ZMQ_LINGER, 100); // ms
+    _socket->set(zmq::sockopt::tcp_keepalive, 1); // turn on tcp keepalive, do these configuration before connect
+    _socket->set(zmq::sockopt::tcp_keepalive_idle, 2); // the interval between the last data packet sent (simple ACKs are not considered data) and the first keepalive probe; after the connection is marked to need keepalive, this counter is not used any further
+    _socket->set(zmq::sockopt::tcp_keepalive_intvl, 2); // the interval between subsequential keepalive probes, regardless of what the connection has exchanged in the meantime
+    _socket->set(zmq::sockopt::tcp_keepalive_cnt, 2); // the number of unacknowledged probes to send before considering the connection dead and notifying the application layer
+    _socket->set(zmq::sockopt::sndhwm, 2);
+    _socket->set(zmq::sockopt::linger, 100); // ms
     std::ostringstream port_stream;
-    port_stream << _port;
-    _socket->bind (("tcp://*:" + port_stream.str()).c_str());
+    port_stream << "tcp://*:" << _port;
+    _socket->bind(port_stream.str());
 }
 
 void ZmqPublisher::_DestroySocket()
@@ -251,7 +251,7 @@ std::string ZmqClient::Call(const std::string& msg, const double timeout, const 
     bool recreatedonce = false;
     while (GetMilliTime() - starttime < timeout*1000.0) {
         try {
-            _socket->send(request);
+            _socket->send(request, zmq::send_flags::none);
             break;
         } catch (const zmq::error_t& e) {
             if (e.num() == EAGAIN) {
@@ -321,12 +321,11 @@ std::string ZmqClient::Call(const std::string& msg, const double timeout, const 
                 timeoutms = timeout * 1000.0;
             }
 
-            zmq::poll(&pollitem, 1, timeoutms);
+            zmq::poll(&pollitem, 1, std::chrono::milliseconds{timeoutms});
             receivedonce = true;
             if (pollitem.revents & ZMQ_POLLIN) {
-                _socket->recv(&reply);
-                std::string replystring((char *) reply.data (), (size_t) reply.size());
-                return replystring;
+                _socket->recv(reply);
+                return reply.to_string();
             } else{
                 std::stringstream ss;
                 if (msg.length() > 1000) {
@@ -402,16 +401,16 @@ void ZmqClient::_InitializeSocket(boost::shared_ptr<zmq::context_t> context)
         _sharedcontext = false;
     }
     _socket.reset(new zmq::socket_t ((*(zmq::context_t*)_context.get()), ZMQ_REQ));
-    _socket->setsockopt(ZMQ_TCP_KEEPALIVE, 1); // turn on tcp keepalive, do these configuration before connect
-    _socket->setsockopt(ZMQ_TCP_KEEPALIVE_IDLE, 2); // the interval between the last data packet sent (simple ACKs are not considered data) and the first keepalive probe; after the connection is marked to need keepalive, this counter is not used any further
-    _socket->setsockopt(ZMQ_TCP_KEEPALIVE_INTVL, 2); // the interval between subsequential keepalive probes, regardless of what the connection has exchanged in the meantime
-    _socket->setsockopt(ZMQ_TCP_KEEPALIVE_CNT, 2); // the number of unacknowledged probes to send before considering the connection dead and notifying the application layer
+    _socket->set(zmq::sockopt::tcp_keepalive, 1); // turn on tcp keepalive, do these configuration before connect
+    _socket->set(zmq::sockopt::tcp_keepalive_idle, 2); // the interval between the last data packet sent (simple ACKs are not considered data) and the first keepalive probe; after the connection is marked to need keepalive, this counter is not used any further
+    _socket->set(zmq::sockopt::tcp_keepalive_intvl, 2); // the interval between subsequential keepalive probes, regardless of what the connection has exchanged in the meantime
+    _socket->set(zmq::sockopt::tcp_keepalive_cnt, 2); // the number of unacknowledged probes to send before considering the connection dead and notifying the application layer
     std::ostringstream port_stream;
-    port_stream << _port;
+    port_stream << "tcp://" << _host << ':' << _port;
     std::stringstream ss;
     ss << "connecting to socket at " << _host << ":" << _port;
     MUJIN_LOG_INFO(ss.str());
-    _socket->connect (("tcp://" + _host + ":" + port_stream.str()).c_str());
+    _socket->connect(port_stream.str());
 }
 
 void ZmqClient::_DestroySocket()
@@ -437,7 +436,7 @@ unsigned int ZmqServer::Recv(std::string& data, long timeout)
 {
     // wait timeout in millisecond for message
     if (timeout > 0) {
-        zmq::poll(&_pollitem, 1, timeout); 
+        zmq::poll(&_pollitem, 1, std::chrono::milliseconds{timeout});
         if ((_pollitem.revents & ZMQ_POLLIN) == 0)
         {
             // did not receive anything
@@ -445,10 +444,9 @@ unsigned int ZmqServer::Recv(std::string& data, long timeout)
         }
     }
 
-    const bool ret = _socket->recv(&_reply, ZMQ_NOBLOCK);
+    const bool ret = (bool)_socket->recv(_reply, zmq::recv_flags::dontwait);
     if (ret && _reply.size() > 0) {
-        data.resize(_reply.size());
-        std::copy((uint8_t*)_reply.data(), (uint8_t*)_reply.data() + _reply.size(), data.begin());
+        data = _reply.to_string();
         return _reply.size();
     } else {
         return 0;
@@ -459,7 +457,7 @@ void ZmqServer::Send(const std::string& message)
 {
     zmq::message_t request(message.size());
     memcpy((void *)request.data(), message.c_str(), message.size());
-    _socket->send(request);
+    _socket->send(request, zmq::send_flags::none);
 }
 
 void ZmqServer::_InitializeSocket(boost::shared_ptr<zmq::context_t> context)
@@ -473,10 +471,10 @@ void ZmqServer::_InitializeSocket(boost::shared_ptr<zmq::context_t> context)
     }
 
     _socket.reset(new zmq::socket_t((*(zmq::context_t*)_context.get()), ZMQ_REP));
-    _socket->setsockopt(ZMQ_TCP_KEEPALIVE, 1); // turn on tcp keepalive, do these configuration before connect
-    _socket->setsockopt(ZMQ_TCP_KEEPALIVE_IDLE, 2); // the interval between the last data packet sent (simple ACKs are not considered data) and the first keepalive probe; after the connection is marked to need keepalive, this counter is not used any further
-    _socket->setsockopt(ZMQ_TCP_KEEPALIVE_INTVL, 2); // the interval between subsequential keepalive probes, regardless of what the connection has exchanged in the meantime
-    _socket->setsockopt(ZMQ_TCP_KEEPALIVE_CNT, 2); // the number of unacknowledged probes to send before considering the connection dead and notifying the application layer
+    _socket->set(zmq::sockopt::tcp_keepalive, 1); // turn on tcp keepalive, do these configuration before connect
+    _socket->set(zmq::sockopt::tcp_keepalive_idle, 2); // the interval between the last data packet sent (simple ACKs are not considered data) and the first keepalive probe; after the connection is marked to need keepalive, this counter is not used any further
+    _socket->set(zmq::sockopt::tcp_keepalive_intvl, 2); // the interval between subsequential keepalive probes, regardless of what the connection has exchanged in the meantime
+    _socket->set(zmq::sockopt::tcp_keepalive_cnt, 2); // the number of unacknowledged probes to send before considering the connection dead and notifying the application layer
 
     // setup the pollitem
     memset(&_pollitem, 0, sizeof(_pollitem));
@@ -485,7 +483,7 @@ void ZmqServer::_InitializeSocket(boost::shared_ptr<zmq::context_t> context)
 
     std::ostringstream endpoint;
     endpoint << "tcp://*:" << _port;
-    _socket->bind(endpoint.str().c_str());
+    _socket->bind(endpoint.str());
     std::stringstream ss;
     ss << "binded to " << endpoint.str();
     MUJIN_LOG_INFO(ss.str());


### PR DESCRIPTION
Due to the upgraded header zmq C++ header file applied to the bullseye branch recently, compiling this causes the compiler to belch out a ton of unnecessary warnings due to deprecation and the like.

This pull request aims to fix those issues.