### PR TITLE
Fetch attached sensors from connected bodies in `RobotResource::GetAttachedSensors`

### DIFF
--- a/include/mujincontrollerclient/mujincontrollerclient.h
+++ b/include/mujincontrollerclient/mujincontrollerclient.h
@@ -894,16 +894,13 @@ public:
     }
 
     virtual void GetTools(std::vector<ToolResourcePtr>& tools);
-    virtual void GetAttachedSensors(std::vector<AttachedSensorResourcePtr>& attachedsensors);
+    virtual void GetAttachedSensors(std::vector<AttachedSensorResourcePtr>& attachedsensors, bool useConnectedBodies = true);
 
     // attachments
     // ikparams
     // images
     int numdof;
     std::string simulation_file;
-
-private:
-    virtual void PushAttachedSensor(std::vector<AttachedSensorResourcePtr>& attachedsensors, rapidjson::Value& attachedSensor);
 };
 
 class MUJINCLIENT_API SceneResource : public WebResource

--- a/include/mujincontrollerclient/mujincontrollerclient.h
+++ b/include/mujincontrollerclient/mujincontrollerclient.h
@@ -901,6 +901,9 @@ public:
     // images
     int numdof;
     std::string simulation_file;
+
+private:
+    virtual void PushAttachedSensor(std::vector<AttachedSensorResourcePtr>& attachedsensors, rapidjson::Value& attachedSensor);
 };
 
 class MUJINCLIENT_API SceneResource : public WebResource

--- a/src/binpickingtask.cpp
+++ b/src/binpickingtask.cpp
@@ -1736,29 +1736,24 @@ void utils::GetSensorData(SceneResource& scene, const std::string& bodyname, con
 
 void utils::GetSensorTransform(SceneResource& scene, const std::string& bodyname, const std::string& sensorname, Transform& result, const std::string& unit)
 {
-    SceneResource::InstObjectPtr cameraobj;
-    if (scene.FindInstObject(bodyname, cameraobj)) {
-        std::vector<RobotResource::AttachedSensorResourcePtr> attachedsensors;
-        utils::GetAttachedSensors(scene, bodyname, attachedsensors);
-        for (size_t i=0; i<attachedsensors.size(); ++i) {
-            if (attachedsensors.at(i)->name == sensorname) {
-                Transform transform;
-                std::copy(attachedsensors.at(i)->quaternion, attachedsensors.at(i)->quaternion+4, transform.quaternion);
-                std::copy(attachedsensors.at(i)->translate, attachedsensors.at(i)->translate+3, transform.translate);
-                if (unit == "m") { //?!
-                    transform.translate[0] *= 0.001;
-                    transform.translate[1] *= 0.001;
-                    transform.translate[2] *= 0.001;
-                }
-
-                result = transform;
-                return;
+    std::vector<RobotResource::AttachedSensorResourcePtr> attachedsensors;
+    utils::GetAttachedSensors(scene, bodyname, attachedsensors);
+    for (size_t i=0; i<attachedsensors.size(); ++i) {
+        if (attachedsensors.at(i)->name == sensorname) {
+            Transform transform;
+            std::copy(attachedsensors.at(i)->quaternion, attachedsensors.at(i)->quaternion+4, transform.quaternion);
+            std::copy(attachedsensors.at(i)->translate, attachedsensors.at(i)->translate+3, transform.translate);
+            if (unit == "m") { //?!
+                transform.translate[0] *= 0.001;
+                transform.translate[1] *= 0.001;
+                transform.translate[2] *= 0.001;
             }
+
+            result = transform;
+            return;
         }
-        throw MujinException("Could not find attached sensor " + sensorname + " on " + bodyname + ".", MEC_Failed);
-    } else {
-        throw MujinException("Could not find camera body " + bodyname +".", MEC_Failed);
     }
+    throw MujinException("Could not find attached sensor " + sensorname + " on " + bodyname + ".", MEC_Failed);
 }
 
 void utils::DeleteObject(SceneResource& scene, const std::string& name)

--- a/src/binpickingtask.cpp
+++ b/src/binpickingtask.cpp
@@ -1738,11 +1738,13 @@ void utils::GetSensorTransform(SceneResource& scene, const std::string& bodyname
 {
     SceneResource::InstObjectPtr cameraobj;
     if (scene.FindInstObject(bodyname, cameraobj)) {
-        for (size_t i=0; i<cameraobj->attachedsensors.size(); ++i) {
-            if (cameraobj->attachedsensors.at(i).name == sensorname) {
+        std::vector<RobotResource::AttachedSensorResourcePtr> attachedsensors;
+        utils::GetAttachedSensors(scene, bodyname, attachedsensors);
+        for (size_t i=0; i<attachedsensors.size(); ++i) {
+            if (attachedsensors.at(i)->name == sensorname) {
                 Transform transform;
-                std::copy(cameraobj->attachedsensors.at(i).quaternion, cameraobj->attachedsensors.at(i).quaternion+4, transform.quaternion);
-                std::copy(cameraobj->attachedsensors.at(i).translate, cameraobj->attachedsensors.at(i).translate+3, transform.translate);
+                std::copy(attachedsensors.at(i)->quaternion, attachedsensors.at(i)->quaternion+4, transform.quaternion);
+                std::copy(attachedsensors.at(i)->translate, attachedsensors.at(i)->translate+3, transform.translate);
                 if (unit == "m") { //?!
                     transform.translate[0] *= 0.001;
                     transform.translate[1] *= 0.001;

--- a/src/mujincontrollerclient.cpp
+++ b/src/mujincontrollerclient.cpp
@@ -463,18 +463,15 @@ void RobotResource::GetAttachedSensors(std::vector<AttachedSensorResourcePtr>& a
             std::string connectedBodyName = GetJsonValueByKey<std::string>(*itConnectedBody, "name");
             rapidjson::Document rConnectedBodyInstObjects(rapidjson::kObjectType);
             controller->CallGet(str(boost::format("scene/%s/instobject/?format=json&limit=0&fields=attachedsensors,object_pk,name")%connectedBodyScenePk), rConnectedBodyInstObjects);
-            for (rapidjson::Document::ConstValueIterator itConnectedBodyInstObject = rConnectedBodyInstObjects["objects"].Begin(); itConnectedBodyInstObject != rConnectedBodyInstObjects["objects"].End(); ++itConnectedBodyInstObject) {
+            for (rapidjson::Document::ValueIterator itConnectedBodyInstObject = rConnectedBodyInstObjects["objects"].Begin(); itConnectedBodyInstObject != rConnectedBodyInstObjects["objects"].End(); ++itConnectedBodyInstObject) {
                 if (!itConnectedBodyInstObject->HasMember("attachedsensors") || !(*itConnectedBodyInstObject)["attachedsensors"].IsArray() || (*itConnectedBodyInstObject)["attachedsensors"].Size() == 0) {
                     continue;
                 }
-                std::string connectedBodyObjectPk = GetJsonValueByKey<std::string>(*itConnectedBodyInstObject, "object_pk");
-                rapidjson::Document rConnectedBodyRobotAttachedSensors(rapidjson::kObjectType);
-                controller->CallGet(str(boost::format("robot/%s/attachedsensor/?format=json")%connectedBodyObjectPk), rConnectedBodyRobotAttachedSensors);
-                rapidjson::Value& rConnectedBodyAttachedSensors = rConnectedBodyRobotAttachedSensors["attachedsensors"];
+                rapidjson::Value& rConnectedBodyAttachedSensors = (*itConnectedBodyInstObject)["attachedsensors"];
                 for (rapidjson::Document::ValueIterator itConnectedBodyAttachedSensor = rConnectedBodyAttachedSensors.Begin(); itConnectedBodyAttachedSensor != rConnectedBodyAttachedSensors.End(); ++itConnectedBodyAttachedSensor) {
                     std::string sensorname = GetJsonValueByKey<std::string>(*itConnectedBodyAttachedSensor, "name");
                     std::string resolvedSensorName = str(boost::format("%s_%s")%connectedBodyName%sensorname);
-                    SetJsonValueByKey(*itConnectedBodyAttachedSensor, "name", resolvedSensorName, rConnectedBodyRobotAttachedSensors.GetAllocator());
+                    SetJsonValueByKey(*itConnectedBodyAttachedSensor, "name", resolvedSensorName, rConnectedBodyInstObjects.GetAllocator());
                     objects.PushBack(*itConnectedBodyAttachedSensor, pt.GetAllocator());
                     attachedSensorsSize++;
                 }


### PR DESCRIPTION
This PR seeks to address the issue of the controller client user hitting an error when calling `mujinclient::utils::GetSensorData/GetSensorTransform` with the `sensorname` argument referring to a connected body camera of the robot referred to with the `bodyname` argument.

The primary change this MR makes is adding a section in `RobotResource::GetAttachedSensors` for gathering attached sensor pointers from the robot resource's connected bodies before merging them into the attached sensors array that the method later iterates on.