### PR TITLE
Fix: Memory leak from ResultGetBinpickingState::RegisterMinViableRegionInfo::graspModelInfo

### DIFF
--- a/include/mujincontrollerclient/binpickingtask.h
+++ b/include/mujincontrollerclient/binpickingtask.h
@@ -217,7 +217,9 @@ public:
             public:
                 // Since ResultGetBinpickingState needs to be copyable while rapidjson::Document is not, there needs to be a small wrapper
                 CopyableRapidJsonDocument& operator=(const CopyableRapidJsonDocument& other) {
-                    CopyFrom(other, GetAllocator());  // Note: This function deallocates old values before copying
+                    SetNull();
+                    GetAllocator().Clear();
+                    CopyFrom(other, GetAllocator());
                     return *this;
                 }
             };

--- a/src/binpickingtask.cpp
+++ b/src/binpickingtask.cpp
@@ -575,7 +575,7 @@ void BinPickingTaskResource::ResultGetBinpickingState::Parse(const rapidjson::Va
         registerMinViableRegionInfo.graspModelInfo.GetAllocator().Clear();
         const rapidjson::Value* graspModelInfoJson = rapidjson::Pointer("/registerMinViableRegionInfo/graspModelInfo").Get(v);
         if( !!graspModelInfoJson && graspModelInfoJson->IsObject() ) {
-             registerMinViableRegionInfo.graspModelInfo.CopyFrom(*graspModelInfoJson, registerMinViableRegionInfo.graspModelInfo.GetAllocator());
+            registerMinViableRegionInfo.graspModelInfo.CopyFrom(*graspModelInfoJson, registerMinViableRegionInfo.graspModelInfo.GetAllocator());
         }
     }
     registerMinViableRegionInfo.minCornerVisibleDist = GetJsonValueByPath<double>(v, "/registerMinViableRegionInfo/minCornerVisibleDist", 30);

--- a/src/binpickingtask.cpp
+++ b/src/binpickingtask.cpp
@@ -571,9 +571,11 @@ void BinPickingTaskResource::ResultGetBinpickingState::Parse(const rapidjson::Va
     registerMinViableRegionInfo.robotDepartStopTimestamp = GetJsonValueByPath<double>(v, "/registerMinViableRegionInfo/robotDepartStopTimestamp", 0);
     registerMinViableRegionInfo.transferSpeedMult = GetJsonValueByPath<double>(v, "/registerMinViableRegionInfo/transferSpeedMult", 1.0);
     {
+        registerMinViableRegionInfo.graspModelInfo.SetNull();
+        registerMinViableRegionInfo.graspModelInfo.GetAllocator().Clear();
         const rapidjson::Value* graspModelInfoJson = rapidjson::Pointer("/registerMinViableRegionInfo/graspModelInfo").Get(v);
         if( !!graspModelInfoJson && graspModelInfoJson->IsObject() ) {
-            registerMinViableRegionInfo.graspModelInfo.CopyFrom(*graspModelInfoJson, registerMinViableRegionInfo.graspModelInfo.GetAllocator());
+             registerMinViableRegionInfo.graspModelInfo.CopyFrom(*graspModelInfoJson, registerMinViableRegionInfo.graspModelInfo.GetAllocator());
         }
     }
     registerMinViableRegionInfo.minCornerVisibleDist = GetJsonValueByPath<double>(v, "/registerMinViableRegionInfo/minCornerVisibleDist", 30);


### PR DESCRIPTION
This patch adds lines to clear memory allocated for previous contents before copying new contents. (`rapidjson::Document::CopyFrom()` does not deallocate memory implicitly.) It also properly clears a previous value of `graspModelInfo` when a value is not given in the parsing function.