### PR TITLE
Revert "Fetch attached sensors from connected bodies in `RobotResource::GetAttachedSensors`"

### DIFF
--- a/include/mujincontrollerclient/mujincontrollerclient.h
+++ b/include/mujincontrollerclient/mujincontrollerclient.h
@@ -895,7 +895,7 @@ public:
     }
 
     virtual void GetTools(std::vector<ToolResourcePtr>& tools);
-    virtual void GetAttachedSensors(std::vector<AttachedSensorResourcePtr>& attachedsensors, bool useConnectedBodies = true);
+    virtual void GetAttachedSensors(std::vector<AttachedSensorResourcePtr>& attachedsensors);
 
     // attachments
     // ikparams

--- a/src/binpickingtask.cpp
+++ b/src/binpickingtask.cpp
@@ -1740,24 +1740,27 @@ void utils::GetSensorData(SceneResource& scene, const std::string& bodyname, con
 
 void utils::GetSensorTransform(SceneResource& scene, const std::string& bodyname, const std::string& sensorname, Transform& result, const std::string& unit)
 {
-    std::vector<RobotResource::AttachedSensorResourcePtr> attachedsensors;
-    utils::GetAttachedSensors(scene, bodyname, attachedsensors);
-    for (size_t i=0; i<attachedsensors.size(); ++i) {
-        if (attachedsensors.at(i)->name == sensorname) {
-            Transform transform;
-            std::copy(attachedsensors.at(i)->quaternion, attachedsensors.at(i)->quaternion+4, transform.quaternion);
-            std::copy(attachedsensors.at(i)->translate, attachedsensors.at(i)->translate+3, transform.translate);
-            if (unit == "m") { //?!
-                transform.translate[0] *= 0.001;
-                transform.translate[1] *= 0.001;
-                transform.translate[2] *= 0.001;
-            }
+    SceneResource::InstObjectPtr cameraobj;
+    if (scene.FindInstObject(bodyname, cameraobj)) {
+        for (size_t i=0; i<cameraobj->attachedsensors.size(); ++i) {
+            if (cameraobj->attachedsensors.at(i).name == sensorname) {
+                Transform transform;
+                std::copy(cameraobj->attachedsensors.at(i).quaternion, cameraobj->attachedsensors.at(i).quaternion+4, transform.quaternion);
+                std::copy(cameraobj->attachedsensors.at(i).translate, cameraobj->attachedsensors.at(i).translate+3, transform.translate);
+                if (unit == "m") { //?!
+                    transform.translate[0] *= 0.001;
+                    transform.translate[1] *= 0.001;
+                    transform.translate[2] *= 0.001;
+                }
 
-            result = transform;
-            return;
+                result = transform;
+                return;
+            }
         }
+        throw MujinException("Could not find attached sensor " + sensorname + " on " + bodyname + ".", MEC_Failed);
+    } else {
+        throw MujinException("Could not find camera body " + bodyname +".", MEC_Failed);
     }
-    throw MujinException("Could not find attached sensor " + sensorname + " on " + bodyname + ".", MEC_Failed);
 }
 
 void utils::DeleteObject(SceneResource& scene, const std::string& name)

--- a/src/mujincontrollerclient.cpp
+++ b/src/mujincontrollerclient.cpp
@@ -446,45 +446,43 @@ RobotResource::AttachedSensorResource::AttachedSensorResource(ControllerClientPt
 {
 }
 
-void RobotResource::GetAttachedSensors(std::vector<AttachedSensorResourcePtr>& attachedsensors, bool useConnectedBodies)
+void RobotResource::GetAttachedSensors(std::vector<AttachedSensorResourcePtr>& attachedsensors)
 {
     GETCONTROLLERIMPL();
     rapidjson::Document pt(rapidjson::kObjectType);
     controller->CallGet(str(boost::format("robot/%s/attachedsensor/?format=json&limit=0&fields=attachedsensors")%GetPrimaryKey()), pt);
+    rapidjson::Value& objects = pt["attachedsensors"];
+    attachedsensors.resize(objects.Size());
+    size_t sensorNum = 0;
+    for (rapidjson::Document::ValueIterator it = objects.Begin(); it != objects.End(); ++it) {
+        AttachedSensorResourcePtr attachedsensor(new AttachedSensorResource(controller, GetPrimaryKey(), GetJsonValueByKey<std::string>(*it, "pk")));
 
-    rapidjson::Value& rAttachedSensors = pt["attachedsensors"];
-    attachedsensors.resize(rAttachedSensors.Size());
-    size_t attachedSensorIdx = 0;
-    for (rapidjson::Document::ValueIterator itAttachedSensor = rAttachedSensors.Begin(); itAttachedSensor != rAttachedSensors.End(); ++itAttachedSensor) {
-        AttachedSensorResourcePtr attachedsensor(new AttachedSensorResource(controller, GetPrimaryKey(), GetJsonValueByKey<std::string>(*itAttachedSensor, "pk")));
-
-        LoadJsonValueByKey(*itAttachedSensor, "name", attachedsensor->name);
-        LoadJsonValueByKey(*itAttachedSensor, "frame_origin", attachedsensor->frame_origin);
-        LoadJsonValueByKey(*itAttachedSensor, "sensortype", attachedsensor->sensortype);
-        LoadJsonValueByKey(*itAttachedSensor, "quaternion", attachedsensor->quaternion);
-        LoadJsonValueByKey(*itAttachedSensor, "translate", attachedsensor->translate);
-        std::vector<double> distortionCoeffs = GetJsonValueByPath<std::vector<double> > (*itAttachedSensor, "/sensordata/distortion_coeffs");
-
+        LoadJsonValueByKey(*it, "name", attachedsensor->name);
+        LoadJsonValueByKey(*it, "frame_origin", attachedsensor->frame_origin);
+        LoadJsonValueByKey(*it, "sensortype", attachedsensor->sensortype);
+        LoadJsonValueByKey(*it, "quaternion", attachedsensor->quaternion);
+        LoadJsonValueByKey(*it, "translate", attachedsensor->translate);
+        std::vector<double> distortionCoeffs = GetJsonValueByPath<std::vector<double> > (*it, "/sensordata/distortion_coeffs");
         BOOST_ASSERT(distortionCoeffs.size() <= 5);
         for (size_t i = 0; i < distortionCoeffs.size(); i++) {
             attachedsensor->sensordata.distortion_coeffs[i] = distortionCoeffs[i];
         }
-        attachedsensor->sensordata.distortion_model = GetJsonValueByPath<std::string>(*itAttachedSensor, "/sensordata/distortion_model");
-        attachedsensor->sensordata.focal_length = GetJsonValueByPath<Real>(*itAttachedSensor, "/sensordata/focal_length");
-        attachedsensor->sensordata.measurement_time= GetJsonValueByPath<Real>(*itAttachedSensor, "/sensordata/measurement_time");
-        std::vector<double> intrinsics = GetJsonValueByPath<std::vector<double> >(*itAttachedSensor, "/sensordata/intrinsic");
+        attachedsensor->sensordata.distortion_model = GetJsonValueByPath<std::string>(*it, "/sensordata/distortion_model");
+        attachedsensor->sensordata.focal_length = GetJsonValueByPath<Real>(*it, "/sensordata/focal_length");
+        attachedsensor->sensordata.measurement_time= GetJsonValueByPath<Real>(*it, "/sensordata/measurement_time");
+        std::vector<double> intrinsics = GetJsonValueByPath<std::vector<double> >(*it, "/sensordata/intrinsic");
         BOOST_ASSERT(intrinsics.size() <= 6);
         for (size_t i = 0; i < intrinsics.size(); i++) {
             attachedsensor->sensordata.intrinsic[i] = intrinsics[i];
         }
-        std::vector<int> imgdim = GetJsonValueByPath<std::vector<int> >(*itAttachedSensor, "/sensordata/image_dimensions");
+        std::vector<int> imgdim = GetJsonValueByPath<std::vector<int> >(*it, "/sensordata/image_dimensions");
         BOOST_ASSERT(imgdim.size() <= 3);
         for (size_t i = 0; i < imgdim.size(); i++) {
             attachedsensor->sensordata.image_dimensions[i] = imgdim[i];
         }
 
-        if (rapidjson::Pointer("/sensordata/extra_parameters").Get(*itAttachedSensor)) {
-            std::string parameters_string = GetJsonValueByPath<std::string>(*itAttachedSensor, "/sensordata/extra_parameters");
+        if (rapidjson::Pointer("/sensordata/extra_parameters").Get(*it)) {
+            std::string parameters_string = GetJsonValueByPath<std::string>(*it, "/sensordata/extra_parameters");
             //std::cout << "extra param " << parameters_string << std::endl;
             std::list<std::string> results;
             boost::split(results, parameters_string, boost::is_any_of(" "));
@@ -503,37 +501,7 @@ void RobotResource::GetAttachedSensors(std::vector<AttachedSensorResourcePtr>& a
             //std::cout << "no asus param" << std::endl;
         }
 
-        attachedsensors[attachedSensorIdx++] = attachedsensor;
-    }
-
-    rapidjson::Document rRobotConnectedBodies(rapidjson::kObjectType);
-    controller->CallGet(str(boost::format("robot/%s/connectedBody/?format=json")%GetPrimaryKey()), rRobotConnectedBodies);
-    rapidjson::Value& rConnectedBodies = rRobotConnectedBodies["connectedBodies"];
-    if (useConnectedBodies && rConnectedBodies.IsArray() && rConnectedBodies.Size() > 0) {
-        for (rapidjson::Document::ConstValueIterator itConnectedBody = rConnectedBodies.Begin(); itConnectedBody != rConnectedBodies.End(); ++itConnectedBody) {
-            std::string connectedBodyScenePk = controller->GetScenePrimaryKeyFromURI_UTF8(GetJsonValueByKey<std::string>(*itConnectedBody, "url"));
-            std::string connectedBodyName = GetJsonValueByKey<std::string>(*itConnectedBody, "name");
-            rapidjson::Document rConnectedBodyInstObjects(rapidjson::kObjectType);
-            controller->CallGet(str(boost::format("scene/%s/instobject/?format=json&limit=0&fields=attachedsensors,object_pk,name")%connectedBodyScenePk), rConnectedBodyInstObjects);
-            for (rapidjson::Document::ConstValueIterator itConnectedBodyInstObject = rConnectedBodyInstObjects["objects"].Begin(); itConnectedBodyInstObject != rConnectedBodyInstObjects["objects"].End(); ++itConnectedBodyInstObject) {
-                if (!itConnectedBodyInstObject->HasMember("attachedsensors") || !(*itConnectedBodyInstObject)["attachedsensors"].IsArray() || (*itConnectedBodyInstObject)["attachedsensors"].Size() == 0) {
-                    continue;
-                }
-                std::string connectedBodyObjectPk = GetJsonValueByKey<std::string>(*itConnectedBodyInstObject, "object_pk");
-                RobotResourcePtr connectedbodyrobot(new RobotResource(controller,connectedBodyObjectPk));
-                std::vector<AttachedSensorResourcePtr> connectedbodyattachedsensors;
-
-                connectedbodyrobot->GetAttachedSensors(connectedbodyattachedsensors, false);
-
-                for (size_t i = 0; i < connectedbodyattachedsensors.size(); i++) {
-                    std::string resolvedSensorName = str(boost::format("%s_%s")%connectedBodyName%connectedbodyattachedsensors[i]->name);
-                    connectedbodyattachedsensors[i]->name = resolvedSensorName;
-                }
-
-                attachedsensors.reserve(attachedsensors.size() + connectedbodyattachedsensors.size());
-                attachedsensors.insert(attachedsensors.end(), connectedbodyattachedsensors.begin(), connectedbodyattachedsensors.end());
-            }
-        }
+        attachedsensors[sensorNum++] = attachedsensor;
     }
 }
 


### PR DESCRIPTION
Reverts mujin/controllerclientcpp#103

After mujin/controllerclientcpp#103 `GetSensorTransform` returns local transform instead of global, causing floating point cloud issues.

VM should not be using this function to get camera pose in the first place, doing so will ignore robot joint values, since webstack does not apply such information.