### PR TITLE
able to get inner content by utilizing GetJsonValueByPath

### DIFF
--- a/include/mujincontrollerclient/mujincontrollerclient.h
+++ b/include/mujincontrollerclient/mujincontrollerclient.h
@@ -696,8 +696,14 @@ public:
     template<class T>
     inline T Get(const std::string& field, double timeout = 5.0) {
         rapidjson::Document pt(rapidjson::kObjectType);
-        GetWrap(pt, field, timeout);
-        return mujinjson_external::GetJsonValueByKey<T>(pt, field.c_str());
+        std::string path = field;
+        if(path[0]!='/') {
+            path = std::string("/")+field;
+        }
+        std::string fieldToConstraint = path.substr(1);
+        fieldToConstraint = fieldToConstraint.substr(0, fieldToConstraint.find('/'));
+        GetWrap(pt, fieldToConstraint, timeout);
+        return mujinjson_external::GetJsonValueByPath<T>(pt, path.c_str());
     }
 
     /// \brief sets an attribute of this web resource


### PR DESCRIPTION
these will be possible

```
double max_tool_speed_rot = object->Get<double>("robot_motion_parameters/max_tool_speed_rot");
string ikTypeName = object->Get<string>("robot_motion_parameters/ikTypeName");
map<string, vector<int>> params = object->Get<map<string, vector<int>>>("robot_motion_parameters/int_parameters");
```

note that we cannot do `object->Get<map<string, map<string, vector<int>>>>("robot_motion_parameters");`. This is C++ limitation.

---

We will use GetJsonValueByPath, so we add leading / to field variable (after copying to temporary variable).