### PR TITLE
Add AttachmentResource

### DIFF
--- a/include/mujincontrollerclient/mujincontrollerclient.h
+++ b/include/mujincontrollerclient/mujincontrollerclient.h
@@ -813,11 +813,35 @@ public:
     };
     typedef boost::shared_ptr<LinkResource> LinkResourcePtr;
 
+public:
+    class MUJINCLIENT_API AttachmentResource : public WebResource {
+public:
+        AttachmentResource(ControllerClientPtr controller, const std::string& objectpk, const std::string& pk);
+        virtual ~AttachmentResource() {
+        }
+
+        std::string joint_name;
+        std::string joint_type;
+        // std::string joint_sidref;
+        std::string linkpk;
+        std::string pk;
+
+        bool active;
+        Real velocity_limit;
+        Real acceleration_limit;
+        Real upper_limit;
+        Real lower_limit;
+        Real axis[3];
+        Real quaternion[4];
+        Real translate[3];
+    };
+    typedef boost::shared_ptr<AttachmentResource> AttachmentResourcePtr;
 
     ObjectResource(ControllerClientPtr controller, const std::string& pk);
     virtual ~ObjectResource() {
     }
     virtual void GetLinks(std::vector<LinkResourcePtr>& links);
+    virtual void GetAttachments(std::vector<AttachmentResourcePtr>& attachments);
 
     virtual void GetIkParams(std::vector<IkParamResourcePtr>& ikparams);
 

--- a/src/mujincontrollerclient.cpp
+++ b/src/mujincontrollerclient.cpp
@@ -152,6 +152,10 @@ ObjectResource::IkParamResource::IkParamResource(ControllerClientPtr controller,
 {
 }
 
+ObjectResource::AttachmentResource::AttachmentResource(ControllerClientPtr controller, const std::string& objectpk_, const std::string& pk_) : WebResource(controller, str(boost::format("object/%s/attachment")%objectpk_), pk_), pk(pk_)
+{
+}
+
 void ObjectResource::GeometryResource::GetMesh(std::string& primitive, std::vector<std::vector<int> >& indices, std::vector<std::vector<Real> >& vertices)
 {
     GETCONTROLLERIMPL();
@@ -408,6 +412,31 @@ void ObjectResource::GetIkParams(std::vector<ObjectResource::IkParamResourcePtr>
         LoadJsonValueByKey(*it,"translation",ikparam->translation);
         LoadJsonValueByKey(*it,"angle",ikparam->angle);
         ikparams[i++] = ikparam;
+    }
+}
+
+void ObjectResource::GetAttachments(std::vector<ObjectResource::AttachmentResourcePtr>& attachments)
+{
+    GETCONTROLLERIMPL();
+    rapidjson::Document pt(rapidjson::kObjectType);
+    controller->CallGet(str(boost::format("object/%s/attachment/?format=json&limit=0&fields=attachments")%GetPrimaryKey()), pt);
+    rapidjson::Value& objects = pt["attachments"];
+    attachments.resize(objects.Size());
+    size_t i = 0;
+    for (rapidjson::Document::ValueIterator it = objects.Begin(); it != objects.End(); ++it) {
+        AttachmentResourcePtr attachment(new AttachmentResource(controller, GetPrimaryKey(), GetJsonValueByKey<std::string>(*it, "pk")));
+        LoadJsonValueByKey(*it,"joint_name",attachment->joint_name);
+        LoadJsonValueByKey(*it,"joint_type",attachment->joint_type);
+        LoadJsonValueByKey(*it,"linkpk",attachment->linkpk);
+        LoadJsonValueByKey(*it,"active",attachment->active);
+        LoadJsonValueByKey(*it,"velocity_limit",attachment->velocity_limit);
+        LoadJsonValueByKey(*it,"acceleration_limit",attachment->acceleration_limit);
+        LoadJsonValueByKey(*it,"upper_limit",attachment->upper_limit);
+        LoadJsonValueByKey(*it,"lower_limit",attachment->lower_limit);
+        LoadJsonValueByKey(*it,"axis",attachment->axis);
+        LoadJsonValueByKey(*it,"quaternion",attachment->quaternion);
+        LoadJsonValueByKey(*it,"translate",attachment->translate);
+        attachments[i++] = attachment;
     }
 }
 


### PR DESCRIPTION
- Somehow AttachmentResource is not implemented in controllerclientcpp
- It will surely be required after moving robot origin info to joints

(feel free to mark this WIP if there are other plan(s) to add attachments in other ways)