### PR TITLE
pass timeout to _CallGet

### DIFF
--- a/src/controllerclientimpl.cpp
+++ b/src/controllerclientimpl.cpp
@@ -1322,8 +1322,6 @@ long ControllerClientImpl::GetModifiedTime(const std::string& uri, double timeou
 
 void ControllerClientImpl::_DownloadFileFromController(const std::string& desturi, long localtimeval, long &remotetimeval, std::vector<unsigned char>& outputdata, double timeout)
 {
-    CURL_OPTION_SAVE_SETTER(_curl, CURLOPT_TIMEOUT_MS, 0L, (long)(timeout * 1000L));
-
     remotetimeval = 0;
 
     // ask for remote file time

--- a/src/controllerclientimpl.cpp
+++ b/src/controllerclientimpl.cpp
@@ -1334,7 +1334,7 @@ void ControllerClientImpl::_DownloadFileFromController(const std::string& destur
     CURL_OPTION_SAVE_SETTER(_curl, CURLOPT_TIMEVALUE, 0L, localtimeval > 0 ? localtimeval : 0L);
 
     // do the get call
-    long http_code = _CallGet(desturi, outputdata, 0);
+    long http_code = _CallGet(desturi, outputdata, 0, timeout);
     if ((http_code != 200 && http_code != 304)) {
         if (outputdata.size() > 0) {
             std::stringstream ss;


### PR DESCRIPTION
otherwise _CallGet sets curl timeout to default of 5s