### PR TITLE
set ZMQ_LINGER when closing REP/REQ sockets

### DIFF
--- a/src/mujinzmq.cpp
+++ b/src/mujinzmq.cpp
@@ -417,6 +417,7 @@ void ZmqClient::_InitializeSocket(boost::shared_ptr<zmq::context_t> context)
 void ZmqClient::_DestroySocket()
 {
     if (!!_socket) {
+        _socket->setsockopt(ZMQ_LINGER, 0);
         _socket->close();
         _socket.reset();
     }
@@ -494,6 +495,7 @@ void ZmqServer::_InitializeSocket(boost::shared_ptr<zmq::context_t> context)
 void ZmqServer::_DestroySocket()
 {
     if (!!_socket) {
+        _socket->setsockopt(ZMQ_LINGER, 0);
         _socket->close();
         _socket.reset();
     }


### PR DESCRIPTION
It is similar to https://github.com/mujin/mujincontrollerclientpy/blob/master/python/mujincontrollerclient/zmqclient.py#L119

----

When new controllerclientcpp is used with old webstack and ExecuteGraphQueryZmq, timeout happens. It is ok. But the thing is, the client program cannot be shutdown properly:

```
(gdb) bt
#0  0x00007f760d220d2f in __GI___poll (fds=fds@entry=0x7ffff06ee9e8, nfds=nfds@entry=1, timeout=timeout@entry=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
#1  0x00007f75eeba8a9d in zmq::signaler_t::wait(int) (this=this@entry=0x3303d58, timeout_=-1) at /home/mujin/mujin/checkoutroot/libzmq/src/signaler.cpp:242
#2  0x00007f75eeb8e012 in zmq::mailbox_t::recv(zmq::command_t*, int) (this=this@entry=0x3303cf0, cmd_=cmd_@entry=0x7ffff06eea80, timeout_=timeout_@entry=-1)
    at /home/mujin/mujin/checkoutroot/libzmq/src/mailbox.cpp:81
#3  0x00007f75eeb816e8 in zmq::ctx_t::terminate() (this=this@entry=0x3303bc0) at /home/mujin/mujin/checkoutroot/libzmq/src/ctx.cpp:181
#4  0x00007f75eebc644a in zmq_ctx_term(void*) (ctx_=0x3303bc0) at /home/mujin/mujin/checkoutroot/libzmq/src/zmq.cpp:156
#5  0x00007f75ef3476fb in zmq::context_t::close() (this=<optimized out>) at /home/mujin/mujin/checkoutroot/controllerclientcpp/include/mujincontrollerclient/zmq.hpp:868
#6  zmq::context_t::close() (this=<optimized out>) at /home/mujin/mujin/checkoutroot/controllerclientcpp/include/mujincontrollerclient/zmq.hpp:861
#7  mujinclient::ControllerClientImpl::~ControllerClientImpl() (this=0x33a92c0, __in_chrg=<optimized out>) at /home/mujin/mujin/checkoutroot/controllerclientcpp/src/controllerclientimpl.cpp:258
#8  0x00007f75ef347c79 in mujinclient::ControllerClientImpl::~ControllerClientImpl() (this=0x33a92c0, __in_chrg=<optimized out>)
    at /home/mujin/mujin/checkoutroot/controllerclientcpp/src/controllerclientimpl.cpp:261
```

On Python, we specify linger= when tearing down. But we don't do similar thing on C++.

pipelineid=345091
Pipeline #513572
