### PR TITLE
fix substr constructor

### DIFF
--- a/include/mujincontrollerclient/mujinjson.h
+++ b/include/mujincontrollerclient/mujinjson.h
@@ -171,7 +171,7 @@ inline void ParseJson(rapidjson::Document& d, const char* str, size_t length) {
     d.GetAllocator().Clear();
     d.Parse<rapidjson::kParseFullPrecisionFlag>(str, length); // parse float in full precision mode
     if (d.HasParseError()) {
-        const std::string substr(str, length < 200 ? length : 200);
+        const std::string substr(str, 0, length < 200 ? length : 200);
 
         throw MujinJSONException(boost::str(boost::format("Json string is invalid (offset %u) %s data is '%s'.")%((unsigned)d.GetErrorOffset())%GetParseError_En(d.GetParseError())%substr));
     }


### PR DESCRIPTION
the correct form of substring constructor has 3 arguments, original string, starting position and length.

apparently starting position was missing.