### PR TITLE
WIP: set default geometry value

### DIFF
--- a/src/mujincontrollerclient.cpp
+++ b/src/mujincontrollerclient.cpp
@@ -332,7 +332,7 @@ void ObjectResource::LinkResource::GetGeometries(std::vector<ObjectResource::Geo
                 ObjectResource::GeometryResourcePtr geometry(new GeometryResource(controller, this->objectpk, GetJsonValueByKey<std::string>(*it, "pk")));
                 geometry->linkpk = linkpk;
                 LoadJsonValueByKey(*it,"name",geometry->name,geometry->pk);
-                LoadJsonValueByKey(*it,"visible",geometry->visible);
+                LoadJsonValueByKey(*it,"visible",geometry->visible,true);
                 LoadJsonValueByKey(*it,"geomtype",geometry->geomtype);
                 LoadJsonValueByKey(*it,"transparency",geometry->transparency);
                 LoadJsonValueByKey(*it,"quaternion",geometry->quaternion);


### PR DESCRIPTION
I found that webstack geometry API does not return "visible" field always, which has to be interpreted as true.

This is the cause of test_planningsystem test_ObjectVisible flakiness.

@woswos @lazydroid There might be some other fields which might need to be filled as well, could you check?

/cc @felixvd @ntohge