### PR TITLE
Add EnableObject

### DIFF
--- a/include/mujincontrollerclient/binpickingtask.h
+++ b/include/mujincontrollerclient/binpickingtask.h
@@ -555,27 +555,27 @@ public:
     /// \param robotname name of the robot to grab with
     /// \param toolname name of the tool to grab with
     /// \param timeout timeout of communication
-    virtual void Grab(const std::string& targetname, const std::string& robotname = "", const std::string& toolname = "", const double timeout = 1);
+    virtual void Grab(const std::string& targetname, const std::string& robotname = "", const std::string& toolname = "", const double timeout = 5);
 
     /// \brief releases object
     /// \param targetname name of the target to release
     /// \param robotname name of the robot to release from
     /// \param toolname name of the tool to release from
     /// \param timeout timeout of communication
-    virtual void Release(const std::string& targetname, const std::string& robotname = "", const std::string& toolname = "", const double timeout = 1);
+    virtual void Release(const std::string& targetname, const std::string& robotname = "", const std::string& toolname = "", const double timeout = 5);
 
     /// \brief enables object
     /// \param objectName name of the target to enable
     /// \param state whether to enable
     /// \param timeout timeout of communication
-    virtual void EnableObject(const std::string& objectName, bool state, const double timeout = 1);
+    virtual void EnableObject(const std::string& objectName, bool state, const double timeout = 5);
 
     /// \brief enables object link
     /// \param objectName name of the target to enable
     /// \param linkName link name of the target to enable
     /// \param state whether to enable
     /// \param timeout timeout of communication
-    virtual void EnableLink(const std::string& objectName, const std::string& linkName, bool state, const double timeout = 1);
+    virtual void EnableLink(const std::string& objectName, const std::string& linkName, bool state, const double timeout = 5);
 
     /// \brief calls planning GetRobotBridgeIOVariableString and returns the contents of the signal in a string with correct endianness
     virtual void GetRobotBridgeIOVariableString(const std::vector<std::string>& ionames, std::vector<std::string>& iovalues, const double timeout=10);

--- a/include/mujincontrollerclient/binpickingtask.h
+++ b/include/mujincontrollerclient/binpickingtask.h
@@ -564,6 +564,19 @@ public:
     /// \param timeout timeout of communication
     virtual void Release(const std::string& targetname, const std::string& robotname = "", const std::string& toolname = "", const double timeout = 1);
 
+    /// \brief enables object
+    /// \param objectName name of the target to enable
+    /// \param state whether to enable
+    /// \param timeout timeout of communication
+    virtual void EnableObject(const std::string& objectName, bool state, const double timeout = 1);
+
+    /// \brief enables object link
+    /// \param objectName name of the target to enable
+    /// \param linkName link name of the target to enable
+    /// \param state whether to enable
+    /// \param timeout timeout of communication
+    virtual void EnableLink(const std::string& objectName, const std::string& linkName, bool state, const double timeout = 1);
+
     /// \brief calls planning GetRobotBridgeIOVariableString and returns the contents of the signal in a string with correct endianness
     virtual void GetRobotBridgeIOVariableString(const std::vector<std::string>& ionames, std::vector<std::string>& iovalues, const double timeout=10);
 

--- a/include/mujincontrollerclient/binpickingtask.h
+++ b/include/mujincontrollerclient/binpickingtask.h
@@ -564,16 +564,16 @@ public:
     /// \param timeout timeout of communication
     virtual void Release(const std::string& targetname, const std::string& robotname = "", const std::string& toolname = "", const double timeout = 5);
 
-    /// \brief enables object
-    /// \param objectName name of the target to enable
-    /// \param state whether to enable
+    /// \brief manipulates enabled state of object
+    /// \param objectName name of the object to modify enabled state of.
+    /// \param state whether to enable (true) or disable (false) link
     /// \param timeout timeout of communication
     virtual void EnableObject(const std::string& objectName, bool state, const double timeout = 5);
 
-    /// \brief enables object link
-    /// \param objectName name of the target to enable
-    /// \param linkName link name of the target to enable
-    /// \param state whether to enable
+    /// \brief manipulates enabled state of link
+    /// \param objectName name of the object link belongs to
+    /// \param linkName name of the link to modify enabled state of.
+    /// \param state whether to enable (true) or disable (false) link.
     /// \param timeout timeout of communication
     virtual void EnableLink(const std::string& objectName, const std::string& linkName, bool state, const double timeout = 5);
 

--- a/src/binpickingtask.cpp
+++ b/src/binpickingtask.cpp
@@ -1757,12 +1757,12 @@ void BinPickingTaskResource::Grab(const std::string& targetname, const std::stri
 {
     SetMapTaskParameters(_ss, _mapTaskParameters);
     _ss << GetJsonString("command", "Grab") << ", ";
-    _ss << GetJsonString("targetname", targetname) << ", ";
+    _ss << ", " << GetJsonString("targetname", targetname);
     if (!robotname.empty()) {
-        _ss << GetJsonString("robotname", robotname) << ", ";
+        _ss << ", " << GetJsonString("robotname", robotname);
     }
     if (!toolname.empty()) {
-        _ss << GetJsonString("toolname", toolname) << ", ";
+        _ss << ", " << GetJsonString("toolname", toolname);
     }
     _ss << "}";
     rapidjson::Document d;
@@ -1772,14 +1772,37 @@ void BinPickingTaskResource::Grab(const std::string& targetname, const std::stri
 void BinPickingTaskResource::Release(const std::string& targetname, const std::string& robotname, const std::string& toolname, const double timeout)
 {
     SetMapTaskParameters(_ss, _mapTaskParameters);
-    _ss << GetJsonString("command", "Release") << ", ";
-    _ss << GetJsonString("targetname", targetname) << ", ";
+    _ss << GetJsonString("command", "Release");
+    _ss << ", " << GetJsonString("targetname", targetname);
     if (!robotname.empty()) {
-        _ss << GetJsonString("robotname", robotname) << ", ";
+        _ss << ", " << GetJsonString("robotname", robotname);
     }
     if (!toolname.empty()) {
-        _ss << GetJsonString("toolname", toolname) << ", ";
+        _ss << ", " << GetJsonString("toolname", toolname);
     }
+    _ss << "}";
+    rapidjson::Document d;
+    ExecuteCommand(_ss.str(), d, timeout);
+}
+
+void BinPickingTaskResource::EnableObject(const std::string& objectName, bool state, const double timeout)
+{
+    SetMapTaskParameters(_ss, _mapTaskParameters);
+    _ss << GetJsonString("command", "EnableObject");
+    _ss << ", " << GetJsonString("objectName", objectName);
+    _ss << ", " << GetJsonString("state", state);
+    _ss << "}";
+    rapidjson::Document d;
+    ExecuteCommand(_ss.str(), d, timeout);
+}
+
+void BinPickingTaskResource::EnableLink(const std::string& objectName, const std::string& linkName, bool state, const double timeout)
+{
+    SetMapTaskParameters(_ss, _mapTaskParameters);
+    _ss << GetJsonString("command", "EnableLink");
+    _ss << ", " << GetJsonString("objectName", objectName);
+    _ss << ", " << GetJsonString("linkName", linkName);
+    _ss << ", " << GetJsonString("state", state);
     _ss << "}";
     rapidjson::Document d;
     ExecuteCommand(_ss.str(), d, timeout);


### PR DESCRIPTION
- Adds EnableObject and EnableLink APIs. A customer needs them to reset itl state partially. Corresponding tasks are already implemented in our planningcommon.
    - But we should add the API to master to avoid the name collision in the future.

- Grab/Release json had trailing commas. ujson.loads() seems ignoring them, but let's fix them as well.