### PR TITLE
Fill in error code and message for timeout exception

### DIFF
--- a/src/binpickingtaskzmq.cpp
+++ b/src/binpickingtaskzmq.cpp
@@ -81,12 +81,12 @@ void BinPickingTaskZmqResource::Initialize(const std::string& defaultTaskParamet
 
 void _LogTaskParametersAndThrow(const std::string& taskparameters) {
     std::string errstr;
-    if (taskparameters.size()>1000) {
-        errstr = taskparameters.substr(0, 1000);
+    if (taskparameters.size() > 1000) {
+        errstr = taskparameters.substr(0, 1000 - 3) + "...";
     } else {
         errstr = taskparameters;
     }
-    throw MujinException(boost::str(boost::format("Timed out receiving response of command with taskparameters=%s...")%errstr));
+    throw MujinException(boost::str(boost::format("Timed out receiving response of command with taskparameters=%s")%errstr), MEC_Timeout);
 }
 
 void BinPickingTaskZmqResource::ExecuteCommand(const std::string& taskparameters, rapidjson::Document &pt, const double timeout /* [sec] */, const bool getresult)
@@ -189,8 +189,6 @@ void BinPickingTaskZmqResource::_ExecuteCommandZMQ(const std::string& command, r
             if (!_zmqmujincontrollerclient) {
                 throw MujinException(boost::str(boost::format("Failed to establish ZMQ connection to mujin controller at %s:%d")%_mujinControllerIp%_zmqPort), MEC_Failed);
             }
-        } else if (e.GetCode() == MEC_Timeout) {
-            throw MujinException("");  // Filled by `ExecuteCommand` callers who can access taskparameters more easily
         }
         else {
             throw;


### PR DESCRIPTION
While debugging a timeout problem, I noticed that the exception message changed from its first throw and was lacking information. With this change the message now says it is a timeout exception and what the `taskparameters` where.