### PR TITLE
Avoid redefinition of template default argument

### DIFF
--- a/include/mujincontrollerclient/mujinjson.h
+++ b/include/mujincontrollerclient/mujinjson.h
@@ -554,7 +554,8 @@ inline void LoadJsonValue(const rapidjson::GenericValue<Encoding, Allocator>& v,
     }
 }
 
-template<typename T, class AllocT, typename Encoding=rapidjson::UTF8<>, typename Allocator=rapidjson::MemoryPoolAllocator<> >
+// default template arguments provided in forward declaration
+template<typename T, class AllocT, typename Encoding, typename Allocator>
 inline void LoadJsonValue(const rapidjson::GenericValue<Encoding, Allocator>& v, std::vector<T, AllocT>& t) {
     if (v.IsArray()) {
         t.clear();
@@ -569,7 +570,8 @@ inline void LoadJsonValue(const rapidjson::GenericValue<Encoding, Allocator>& v,
     }
 }
 
-template<typename T, size_t N, typename Encoding=rapidjson::UTF8<>, typename Allocator=rapidjson::MemoryPoolAllocator<> >
+// default template arguments provided in forward declaration
+template<typename T, size_t N, typename Encoding, typename Allocator>
 inline void LoadJsonValue(const rapidjson::GenericValue<Encoding, Allocator>& v, std::array<T, N>& t) {
     if (v.IsArray()) {
         if (v.GetArray().Size() != N) {
@@ -775,7 +777,8 @@ inline void SaveJsonValue(rapidjson::GenericValue<Encoding, Allocator>& v, const
     v.PushBack(rSecond, alloc);
 }
 
-template<typename T, class AllocT=std::allocator<T>, typename Encoding, typename Allocator, typename Allocator2 >
+// default template arguments provided in forward declaration
+template<typename T, class AllocT, typename Encoding, typename Allocator, typename Allocator2 >
 inline void SaveJsonValue(rapidjson::GenericValue<Encoding, Allocator>& v, const std::vector<T, AllocT>& t, Allocator2& alloc) {
     v.SetArray();
     v.Reserve(t.size(), alloc);
@@ -1121,7 +1124,8 @@ inline void ValidateJsonString(const std::string& str) {
     }
 }
 
-template<typename Encoding=rapidjson::UTF8<>, typename Allocator=rapidjson::MemoryPoolAllocator<> >
+// default template arguments provided in forward declaration
+template<typename Encoding, typename Allocator>
 inline std::string GetJsonString(const rapidjson::GenericValue<Encoding, Allocator>& t) {
     rapidjson::GenericDocument<Encoding, Allocator> d;
     SaveJsonValue(d, t, d.GetAllocator());


### PR DESCRIPTION
gcc 12 raises this

```
In file included from /home/mujin/mujin/checkoutroot/controllerclientcpp/include/mujincontrollerclient/mujincontrollerclient.h:60,
                 from /home/mujin/mujin/checkoutroot/controllerclientcpp/src/common.h:21,
                 from /home/mujin/mujin/checkoutroot/controllerclientcpp/src/common.cpp:14:
/home/mujin/mujin/checkoutroot/controllerclientcpp/include/mujincontrollerclient/mujinjson.h:557:36: error: redefinition of default argument for ‘class Encoding’
  557 | template<typename T, class AllocT, typename Encoding=rapidjson::UTF8<>, typename Allocator=rapidjson::MemoryPoolAllocator<> >
      |                                    ^~~~~~~~
/home/mujin/mujin/checkoutroot/controllerclientcpp/include/mujincontrollerclient/mujinjson.h:514:56: note: original definition appeared here
  514 | template<typename T, class AllocT = std::allocator<T>, typename Encoding=rapidjson::UTF8<>, typename Allocator=rapidjson::MemoryPoolAllocator<> >
      |                                                        ^~~~~~~~
/home/mujin/mujin/checkoutroot/controllerclientcpp/include/mujincontrollerclient/mujinjson.h:572:32: error: redefinition of default argument for ‘class Encoding’
  572 | template<typename T, size_t N, typename Encoding=rapidjson::UTF8<>, typename Allocator=rapidjson::MemoryPoolAllocator<> >
      |                                ^~~~~~~~
/home/mujin/mujin/checkoutroot/controllerclientcpp/include/mujincontrollerclient/mujinjson.h:517:32: note: original definition appeared here
  517 | template<typename T, size_t N, typename Encoding=rapidjson::UTF8<>, typename Allocator=rapidjson::MemoryPoolAllocator<> >
      |                                ^~~~~~~~
/home/mujin/mujin/checkoutroot/controllerclientcpp/include/mujincontrollerclient/mujinjson.h:781:22: error: redefinition of default argument for ‘class AllocT’
  781 | template<typename T, class AllocT=std::allocator<T>, typename Encoding, typename Allocator, typename Allocator2 >
      |                      ^~~~~
/home/mujin/mujin/checkoutroot/controllerclientcpp/include/mujincontrollerclient/mujinjson.h:756:22: note: original definition appeared here
  756 | template<typename T, class AllocT = std::allocator<T>, typename Encoding=rapidjson::UTF8<>, typename Allocator=rapidjson::MemoryPoolAllocator<>, typename Allocator2=rapidjson::MemoryPoolAllocator<> >
      |                      ^~~~~
/home/mujin/mujin/checkoutroot/controllerclientcpp/include/mujincontrollerclient/mujinjson.h:1127:10: error: redefinition of default argument for ‘class Encoding’
 1127 | template<typename Encoding=rapidjson::UTF8<>, typename Allocator=rapidjson::MemoryPoolAllocator<> >
      |          ^~~~~~~~
/home/mujin/mujin/checkoutroot/controllerclientcpp/include/mujincontrollerclient/mujinjson.h:139:10: note: original definition appeared here
  139 | template<typename Encoding=rapidjson::UTF8<>, typename Allocator=rapidjson::MemoryPoolAllocator<> >
      |          ^~~~~~~~
```

also, even on Debian 11, clang raises this

```
In file included from /home/mujin/mujin/checkoutroot/controllerclientcpp/src/controllerclientimpl.cpp:14:
In file included from /home/mujin/mujin/checkoutroot/controllerclientcpp/src/common.h:21:
In file included from /home/mujin/mujin/checkoutroot/controllerclientcpp/include/mujincontrollerclient/mujincontrollerclient.h:60:
/home/mujin/mujin/checkoutroot/controllerclientcpp/include/mujincontrollerclient/mujinjson.h:557:54: error: template parameter redefines default argument
template<typename T, class AllocT, typename Encoding=rapidjson::UTF8<>, typename Allocator=rapidjson::MemoryPoolAllocator<> >
                                                     ^
/home/mujin/mujin/checkoutroot/controllerclientcpp/include/mujincontrollerclient/mujinjson.h:514:74: note: previous default template argument defined here
template<typename T, class AllocT = std::allocator<T>, typename Encoding=rapidjson::UTF8<>, typename Allocator=rapidjson::MemoryPoolAllocator<> >
                                                                         ^
```