### PR TITLE
Fix leaky realloc()

### DIFF
--- a/src/mujinjson.cpp
+++ b/src/mujinjson.cpp
@@ -38,10 +38,13 @@ void ParseJsonFile(rapidjson::Document& d, const char* filename, Container& buff
             size_t nTotalToRead = nBufferSize - nFileSize;
             if( nTotalToRead < nChunkSize ) {
                 nBufferSize += nChunkSize;
-                pbuffer = (char*)::realloc(pbuffer, nBufferSize);
-                if( !pbuffer ) {
+                char* maybeNull = (char*)::realloc(pbuffer, nBufferSize);
+                if( !maybeNull ) {
+                    ::close(fd);
+                    ::free(pbuffer);
                     throw MujinJSONException("Could not allocate memory");
                 }
+                pbuffer = maybeNull;
                 nTotalToRead = nBufferSize - nFileSize;
             }
             ssize_t count = ::read(fd, pbuffer + nFileSize, nBufferSize - nFileSize);


### PR DESCRIPTION
`realloc()` may return `NULL`, so when we do:
```
foobar = realloc( foobar );
```
we risk leaking memory, better implementation would be:
```
maybe_good = realloc( foobar )
foobar = maybe_good != NULL ? maybe_good : foobar
....
free( foobar )
```