### PR TITLE
Fix SaveJsonValue for strings when using non-default allocators

### DIFF
--- a/include/mujincontrollerclient/mujinjson.h
+++ b/include/mujincontrollerclient/mujinjson.h
@@ -1076,6 +1076,12 @@ inline void SetJsonValueByKey(rapidjson::GenericValue<Encoding, Allocator>& v, c
     }
 }
 
+template<typename T, typename Encoding, typename Allocator, typename Encoding2, typename Allocator2, typename Allocator3>
+inline void SetJsonValueByKey(rapidjson::GenericValue<Encoding, Allocator>& v, const std::string& key, const rapidjson::GenericValue<Encoding2, Allocator2>& t, Allocator3& alloc)
+{
+    SetJsonValueByKey(v, key.c_str(), t, alloc);
+}
+
 template<typename T, typename Encoding, typename Allocator, typename Allocator2>
 inline void SetJsonValueByKey(rapidjson::GenericValue<Encoding, Allocator>& v, const char* key, const T& t, Allocator2& alloc)
 {
@@ -1091,6 +1097,12 @@ inline void SetJsonValueByKey(rapidjson::GenericValue<Encoding, Allocator>& v, c
         SaveJsonValue(value, t, alloc);
         v.AddMember(name, value, alloc);
     }
+}
+
+template<typename T, typename Encoding, typename Allocator, typename Allocator2>
+inline void SetJsonValueByKey(rapidjson::GenericValue<Encoding, Allocator>& v, const std::string& key, const T& t, Allocator2& alloc)
+{
+    SetJsonValueByKey(v, key.c_str(), t, alloc);
 }
 
 template<typename T, typename Encoding=rapidjson::UTF8<>, typename Allocator=rapidjson::MemoryPoolAllocator<> >

--- a/include/mujincontrollerclient/mujinjson.h
+++ b/include/mujincontrollerclient/mujinjson.h
@@ -872,9 +872,6 @@ inline void SaveJsonValue(rapidjson::GenericDocument<Encoding, Allocator>& v, co
     SaveJsonValue(v, t, v.GetAllocator());
 }
 
-template<typename T, typename U, typename Encoding, typename Allocator, typename Allocator2>
-inline void SetJsonValueByKey(rapidjson::GenericValue<Encoding, Allocator>& v, const U& key, const T& t, Allocator2& alloc);
-
 //get one json value by key, and store it in local data structures
 //return true if key is present. Will return false if the key is not present or the member is Null
 template<typename T, typename Encoding=rapidjson::UTF8<>, typename Allocator=rapidjson::MemoryPoolAllocator<> >

--- a/include/mujincontrollerclient/mujinjson.h
+++ b/include/mujincontrollerclient/mujinjson.h
@@ -1070,8 +1070,8 @@ inline void SetJsonValueByPath(rapidjson::GenericDocument<Encoding, Allocator>& 
     SetJsonValueByPath(d, path, t, d.GetAllocator());
 }
 
-template<typename T, typename U, typename Encoding, typename Allocator, typename Encoding2, typename Allocator2, typename Allocator3>
-inline void SetJsonValueByKey(rapidjson::GenericValue<Encoding, Allocator>& v, const U& key, const rapidjson::GenericValue<Encoding2, Allocator2>& t, Allocator3& alloc)
+template<typename T, typename Encoding, typename Allocator, typename Encoding2, typename Allocator2, typename Allocator3>
+inline void SetJsonValueByKey(rapidjson::GenericValue<Encoding, Allocator>& v, const char* key, const rapidjson::GenericValue<Encoding2, Allocator2>& t, Allocator3& alloc)
 {
     if (!v.IsObject()) {
         throw MujinJSONException("Cannot set value for non-object.");
@@ -1087,8 +1087,8 @@ inline void SetJsonValueByKey(rapidjson::GenericValue<Encoding, Allocator>& v, c
     }
 }
 
-template<typename T, typename U, typename Encoding, typename Allocator, typename Allocator2>
-inline void SetJsonValueByKey(rapidjson::GenericValue<Encoding, Allocator>& v, const U& key, const T& t, Allocator2& alloc)
+template<typename T, typename Encoding, typename Allocator, typename Allocator2>
+inline void SetJsonValueByKey(rapidjson::GenericValue<Encoding, Allocator>& v, const char* key, const T& t, Allocator2& alloc)
 {
     if (!v.IsObject()) {
         throw MujinJSONException("Cannot set value for non-object.");

--- a/include/mujincontrollerclient/mujinjson.h
+++ b/include/mujincontrollerclient/mujinjson.h
@@ -673,18 +673,8 @@ inline void SaveJsonValue(rapidjson::GenericValue<Encoding, Allocator>& v, const
     v.SetString(t.c_str(), alloc);
 }
 
-// for some reason this makes calls ambiguous...
-//template <typename Encoding=rapidjson::UTF8<>, typename Allocator=rapidjson::MemoryPoolAllocator<>>
-//inline void SaveJsonValue(rapidjson::GenericValue<Encoding, Allocator>& v, const char* t, Allocator& alloc) {
-//    v.SetString(t, alloc);
-//}
-
-template <size_t N, typename Encoding, typename Allocator, typename Allocator2>
-inline void SaveJsonValue(rapidjson::GenericValue<Encoding, Allocator>& v, const char (&t)[N], Allocator2& alloc) {
-    v.SetString(t, alloc); // do not pass in the length N since do not know where the nul terminator is
-}
-
-inline void SaveJsonValue(rapidjson::Value& v, const char* t, rapidjson::Value::AllocatorType& alloc) {
+template <typename Encoding, typename Allocator, typename Allocator2>
+inline void SaveJsonValue(rapidjson::GenericValue<Encoding, Allocator>& v, const char* t, Allocator2& alloc) {
     v.SetString(t, alloc);
 }
 
@@ -809,8 +799,10 @@ inline void SaveJsonValue(rapidjson::GenericValue<Encoding, Allocator>& v, const
     }
 }
 
-template<typename T, size_t N, typename Encoding, typename Allocator, typename Allocator2>
-void SaveJsonValue(rapidjson::GenericValue<Encoding, Allocator>& v, const T (&t)[N], Allocator2& alloc) {
+template <typename T, size_t N, typename Encoding, typename Allocator, typename Allocator2,
+          typename = std::enable_if<!std::is_same<char, T>::type>> // Disable instantiation for char[], since we want to handle those as strings
+void SaveJsonValue(rapidjson::GenericValue<Encoding, Allocator>& v, const T (&t)[N], Allocator2& alloc)
+{
     v.SetArray();
     v.Reserve(N, alloc);
     for (size_t i = 0; i < N; ++i) {


### PR DESCRIPTION
When using a non-default allocator, the lack of a type-parameterized `SaveJsonValue` for `const *` causes it to select the `bool` specialization instead. 

The reason that the commented out method was ambiguous before is that `const *` and `const T (&t)[N], T = char` are effectively the same. 
Avoid this issue by explicitly disabling that template when T=char so that it uses the `const char*` specialization.